### PR TITLE
Factory bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'pry'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'simplecov'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,11 @@ GEM
     docile (1.3.1)
     erubi (1.7.1)
     execjs (2.7.0)
+    factory_bot (4.11.1)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
+      railties (>= 3.0.0)
     ffi (1.9.25)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -203,6 +208,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  factory_bot_rails
   figaro
   jbuilder (~> 2.5)
   launchy

--- a/spec/factories/factory_bot.rb
+++ b/spec/factories/factory_bot.rb
@@ -1,0 +1,33 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user_#{n}@aol.com" }
+    sequence(:password) { |n| "password-#{n}" }
+    sequence(:name) { |n| "User #{n}" }
+    sequence(:address) { |n| "Address #{n}" }
+    sequence(:city) { |n| "city #{n}" }
+    sequence(:state) { |n| "state #{n}" }
+    sequence(:zip) { |n| "zip #{n}" }
+  end
+  
+  factory :merchant, class: User do
+    sequence(:email) { |n| "merchant_#{n}@aol.com" }
+    sequence(:password) { |n| "password-#{n}" }
+    sequence(:name) { |n| "Merchant #{n}" }
+    sequence(:address) { |n| "Address #{n}" }
+    sequence(:city) { |n| "city #{n}" }
+    sequence(:state) { |n| "state #{n}" }
+    sequence(:zip) { |n| "zip #{n}" }
+    role { 1 }
+  end
+  
+  factory :admin, class: User do
+    sequence(:email) { |n| "admin_#{n}@aol.com" }
+    sequence(:password) { |n| "password-#{n}" }
+    sequence(:name) { |n| "Admin #{n}" }
+    sequence(:address) { |n| "Address #{n}" }
+    sequence(:city) { |n| "city #{n}" }
+    sequence(:state) { |n| "state #{n}" }
+    sequence(:zip) { |n| "zip #{n}" }
+    role { 2 }
+  end
+end

--- a/spec/factories/factory_bot.rb
+++ b/spec/factories/factory_bot.rb
@@ -29,9 +29,37 @@ FactoryBot.define do
     sequence(:current_price) { |n| n * 100 }
     enabled { true }
     association :user, factory: :merchant
+    
+    factory :disabled_item do
+      enabled { false }
+    end
   end
   
   factory :order do
+    status { pending }
+    user
     
+    factory :fulfilled_order do
+      status { fulfilled }
+    end
+    
+    factory :cancelled_order do
+      status { cancelled }
+    end
+  end
+  
+  factory :order_item do
+    order
+    item
+    sequence(:quantity) { |n| n }
+    sequence(:order_price) { |n| n * 100 }
+    
+    factory :fulfilled_order_item do
+      fulfilled { true }
+    end
+    
+    factory :unfulfilled_order_item do
+      fulfilled { false }
+    end
   end
 end

--- a/spec/factories/factory_bot.rb
+++ b/spec/factories/factory_bot.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:email) { |n| "user_#{n}@aol.com" }
     sequence(:password) { |n| "password-#{n}" }
     sequence(:name) { |n| "User #{n}" }
-    sequence(:address) { |n| "Address #{n}" }
+    sequence(:street) { |n| "Address #{n}" }
     sequence(:city) { |n| "city #{n}" }
     sequence(:state) { |n| "state #{n}" }
     sequence(:zip) { |n| "zip #{n}" }
@@ -13,7 +13,7 @@ FactoryBot.define do
     sequence(:email) { |n| "merchant_#{n}@aol.com" }
     sequence(:password) { |n| "password-#{n}" }
     sequence(:name) { |n| "Merchant #{n}" }
-    sequence(:address) { |n| "Address #{n}" }
+    sequence(:street) { |n| "Address #{n}" }
     sequence(:city) { |n| "city #{n}" }
     sequence(:state) { |n| "state #{n}" }
     sequence(:zip) { |n| "zip #{n}" }
@@ -24,10 +24,20 @@ FactoryBot.define do
     sequence(:email) { |n| "admin_#{n}@aol.com" }
     sequence(:password) { |n| "password-#{n}" }
     sequence(:name) { |n| "Admin #{n}" }
-    sequence(:address) { |n| "Address #{n}" }
+    sequence(:street) { |n| "Address #{n}" }
     sequence(:city) { |n| "city #{n}" }
     sequence(:state) { |n| "state #{n}" }
     sequence(:zip) { |n| "zip #{n}" }
     role { 2 }
+  end
+  
+  factory :item do
+    sequence(:name) { |n| "Item #{n}" }
+    sequence(:image_link) { |n| "#{n}.jpg" }
+    sequence(:inventory) { |n| n }
+    sequence(:description) { |n| "A lovely example of an item#{n}" }
+    sequence(:current_price) { |n| n * 100 }
+    enabled { true }
+    merchant 
   end
 end

--- a/spec/factories/factory_bot.rb
+++ b/spec/factories/factory_bot.rb
@@ -36,15 +36,15 @@ FactoryBot.define do
   end
   
   factory :order do
-    status { pending }
+    status { 'pending' }
     user
     
     factory :fulfilled_order do
-      status { fulfilled }
+      status { 'fulfilled' }
     end
     
     factory :cancelled_order do
-      status { cancelled }
+      status { 'cancelled' }
     end
   end
   

--- a/spec/factories/factory_bot.rb
+++ b/spec/factories/factory_bot.rb
@@ -7,37 +7,31 @@ FactoryBot.define do
     sequence(:city) { |n| "city #{n}" }
     sequence(:state) { |n| "state #{n}" }
     sequence(:zip) { |n| "zip #{n}" }
-  end
-  
-  factory :merchant, class: User do
-    sequence(:email) { |n| "merchant_#{n}@aol.com" }
-    sequence(:password) { |n| "password-#{n}" }
-    sequence(:name) { |n| "Merchant #{n}" }
-    sequence(:street) { |n| "Address #{n}" }
-    sequence(:city) { |n| "city #{n}" }
-    sequence(:state) { |n| "state #{n}" }
-    sequence(:zip) { |n| "zip #{n}" }
-    role { 1 }
-  end
-  
-  factory :admin, class: User do
-    sequence(:email) { |n| "admin_#{n}@aol.com" }
-    sequence(:password) { |n| "password-#{n}" }
-    sequence(:name) { |n| "Admin #{n}" }
-    sequence(:street) { |n| "Address #{n}" }
-    sequence(:city) { |n| "city #{n}" }
-    sequence(:state) { |n| "state #{n}" }
-    sequence(:zip) { |n| "zip #{n}" }
-    role { 2 }
+    
+    factory :merchant do
+      sequence(:email) { |n| "merchant_#{n}@aol.com" }
+      sequence(:name) { |n| "Merchant #{n}" }
+      role { 1 }
+    end
+    
+    factory :admin do
+      sequence(:email) { |n| "admin_#{n}@aol.com" }
+      sequence(:name) { |n| "Admin #{n}" }
+      role { 2 }
+    end
   end
   
   factory :item do
     sequence(:name) { |n| "Item #{n}" }
-    sequence(:image_link) { |n| "#{n}.jpg" }
+    sequence(:image_link) { |n| "https://picsum.photos/#{n}" }
     sequence(:inventory) { |n| n }
     sequence(:description) { |n| "A lovely example of an item#{n}" }
     sequence(:current_price) { |n| n * 100 }
     enabled { true }
-    merchant 
+    association :user, factory: :merchant
+  end
+  
+  factory :order do
+    
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
Adds required gem, files, and files structure for FactoryBot. 
Adds factories for users, items, orders, and order_items with sub-categories where applicable (e.g. admin, merchant, cancelled_orders).
Pending enum set-up and enabled validation fix in Item model.
Tried using in test files and they passed, but this PR does not include any test data created by FactoryBot, just the factories. 