### PR TITLE
Merchant index stats#22

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,7 @@ class UsersController < ApplicationController
     @bottom_merchants_by_time = User.merchants_by_time.reverse[0..2]
     @top_states = User.top_states
     @top_cities = User.top_cities
+    @biggest_orders = Order.biggest_orders
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
       @merchants = User.merchant
     else
       @merchants = User.enabled_merchants
+      @top_merchants_by_quantity = User.merchants_by_quantity
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
     @top_merchants_by_price = User.merchants_by_price
     @top_merchants_by_time = User.merchants_by_time[0..2]
     @bottom_merchants_by_time = User.merchants_by_time.reverse[0..2]
+    @top_states = User.top_states
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
       @merchants = User.enabled_merchants
     end
     @top_merchants_by_quantity = User.merchants_by_quantity
-    @top_merchants_price = User.merchants_by_price
+    @top_merchants_by_price = User.merchants_by_price
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,7 @@ class UsersController < ApplicationController
     end
     @top_merchants_by_quantity = User.merchants_by_quantity
     @top_merchants_by_price = User.merchants_by_price
+    @top_merchants_by_time = User.merchants_by_time[0..2]
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,7 @@ class UsersController < ApplicationController
     @top_merchants_by_time = User.merchants_by_time[0..2]
     @bottom_merchants_by_time = User.merchants_by_time.reverse[0..2]
     @top_states = User.top_states
+    @top_cities = User.top_cities
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
       @merchants = User.enabled_merchants
     end
     @top_merchants_by_quantity = User.merchants_by_quantity
+    @top_merchants_price = User.merchants_by_price
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
     @top_merchants_by_quantity = User.merchants_by_quantity
     @top_merchants_by_price = User.merchants_by_price
     @top_merchants_by_time = User.merchants_by_time[0..2]
+    @bottom_merchants_by_time = User.merchants_by_time.reverse[0..2]
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,8 @@ class UsersController < ApplicationController
       @merchants = User.merchant
     else
       @merchants = User.enabled_merchants
-      @top_merchants_by_quantity = User.merchants_by_quantity
     end
+    @top_merchants_by_quantity = User.merchants_by_quantity
   end
 
   def show

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -10,6 +10,8 @@ class Order < ApplicationRecord
   
   def self.biggest_orders
     joins(:order_items)
+    .where(status: 1)
+    .where("order_items.fulfilled = ?", true)
     .select("orders.*, count(order_items.id) AS item_count")
     .group(:id)
     .order("item_count DESC")

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,4 +7,12 @@ class Order < ApplicationRecord
   has_many :items, through: :order_items
 
   enum status: [:pending, :fulfilled, :cancelled]
+  
+  def self.biggest_orders
+    joins(:order_items)
+    .select("orders.*, count(order_items.id) AS item_count")
+    .group(:id)
+    .order("item_count DESC")
+    .limit(3)
+  end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,5 +1,6 @@
 class OrderItem < ApplicationRecord
-  validates_presence_of :order_id, :item_id, :quantity, :order_price, :fulfilled
+  validates_presence_of :order_id, :item_id, :quantity, :order_price
+  validates :fulfilled, inclusion: {in: [true, false]}  
 
   belongs_to :order
   belongs_to :item

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,9 +22,11 @@ class User < ApplicationRecord
   
   def self.merchants_by_quantity
     User.joins(items: :order_items)
+        .where("order_items.fulfilled = true")
         .group(:id)
         .select("users.*, count(order_items.id) AS quantity")
         .order("quantity DESC")
+        .limit(3)
   end
 
   def enabled_toggle

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
   
   def self.merchants_by_quantity
     User.joins(items: :order_items)
-        .where("order_items.fulfilled = true")
+        .where("order_items.fulfilled = ?", true)
         .group(:id)
         .select("users.*, count(order_items.id) AS quantity")
         .order("quantity DESC")
@@ -31,11 +31,19 @@ class User < ApplicationRecord
   
   def self.merchants_by_price
     User.joins(items: :order_items)
-        .where("order_items.fulfilled = true")
+        .where("order_items.fulfilled = ?", true)
         .group(:id)
         .select("users.*, sum(order_items.order_price) AS total")
         .order("total DESC")
         .limit(3)
+  end
+  
+  def self.merchants_by_time
+    User.joins(items: :order_items)
+        .where("order_items.fulfilled = ?", true)
+        .group(:id)
+        .select("users.*, avg(order_items.updated_at - order_items.created_at) AS average_f_time")
+        .order("average_f_time ASC")
   end
 
   def enabled_toggle

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,18 @@ class User < ApplicationRecord
     .select("users.state, count(orders.id) AS state_count")
     .order("state_count DESC")
     .map(&:state)
+    .limit(3)
+  end
+  
+  def self.top_cities
+    joins(:orders)
+    .where("orders.status = ?", 1)
+    .group(:city)
+    .group(:state)
+    .select("users.city, users.state, count(orders.id) AS city_count")
+    .order("city_count DESC")
+    .limit(3)
+    .map { |user| [user.city, user.state] }
   end
 
   def enabled_toggle

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ApplicationRecord
   
   def self.merchants_by_quantity
     User.joins(items: :order_items)
+        .where(enabled: true)
         .where("order_items.fulfilled = ?", true)
         .group(:id)
         .select("users.*, count(order_items.id) AS quantity")
@@ -31,6 +32,7 @@ class User < ApplicationRecord
   
   def self.merchants_by_price
     User.joins(items: :order_items)
+        .where(enabled: true)
         .where("order_items.fulfilled = ?", true)
         .group(:id)
         .select("users.*, sum(order_items.order_price) AS total")
@@ -40,6 +42,7 @@ class User < ApplicationRecord
   
   def self.merchants_by_time
     User.joins(items: :order_items)
+        .where(enabled: true)
         .where("order_items.fulfilled = ?", true)
         .group(:id)
         .select("users.*, avg(order_items.updated_at - order_items.created_at) AS average_f_time")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,15 @@ class User < ApplicationRecord
         .order("quantity DESC")
         .limit(3)
   end
+  
+  def self.merchants_by_price
+    User.joins(items: :order_items)
+        .where("order_items.fulfilled = true")
+        .group(:id)
+        .select("users.*, sum(order_items.order_price) AS total")
+        .order("total DESC")
+        .limit(3)
+  end
 
   def enabled_toggle
     enabled ? self.update(enabled: false) : self.update(enabled: true)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,13 @@ class User < ApplicationRecord
   def self.default_users
     where(role: :default)
   end
+  
+  def self.merchants_by_quantity
+    User.joins(items: :order_items)
+        .group(:id)
+        .select("users.*, count(order_items.id) AS quantity")
+        .order("quantity DESC")
+  end
 
   def enabled_toggle
     enabled ? self.update(enabled: false) : self.update(enabled: true)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,7 @@ class User < ApplicationRecord
   
   def self.top_states
     joins(:orders)
+    .where("orders.status = ?", 1)
     .group(:state)
     .select("users.state, count(orders.id) AS state_count")
     .order("state_count DESC")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,8 +55,8 @@ class User < ApplicationRecord
     .group(:state)
     .select("users.state, count(orders.id) AS state_count")
     .order("state_count DESC")
-    .map(&:state)
     .limit(3)
+    .map(&:state)
   end
   
   def self.top_cities

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,32 +21,40 @@ class User < ApplicationRecord
   end
   
   def self.merchants_by_quantity
-    User.joins(items: :order_items)
-        .where(enabled: true)
-        .where("order_items.fulfilled = ?", true)
-        .group(:id)
-        .select("users.*, count(order_items.id) AS quantity")
-        .order("quantity DESC")
-        .limit(3)
+    joins(items: :order_items)
+    .where(enabled: true)
+    .where("order_items.fulfilled = ?", true)
+    .group(:id)
+    .select("users.*, count(order_items.id) AS quantity")
+    .order("quantity DESC")
+    .limit(3)
   end
   
   def self.merchants_by_price
-    User.joins(items: :order_items)
-        .where(enabled: true)
-        .where("order_items.fulfilled = ?", true)
-        .group(:id)
-        .select("users.*, sum(order_items.order_price) AS total")
-        .order("total DESC")
-        .limit(3)
+    joins(items: :order_items)
+    .where(enabled: true)
+    .where("order_items.fulfilled = ?", true)
+    .group(:id)
+    .select("users.*, sum(order_items.order_price) AS total")
+    .order("total DESC")
+    .limit(3)
   end
   
   def self.merchants_by_time
-    User.joins(items: :order_items)
-        .where(enabled: true)
-        .where("order_items.fulfilled = ?", true)
-        .group(:id)
-        .select("users.*, avg(order_items.updated_at - order_items.created_at) AS average_f_time")
-        .order("average_f_time ASC")
+    joins(items: :order_items)
+    .where(enabled: true)
+    .where("order_items.fulfilled = ?", true)
+    .group(:id)
+    .select("users.*, avg(order_items.updated_at - order_items.created_at) AS average_f_time")
+    .order("average_f_time ASC")
+  end
+  
+  def self.top_states
+    joins(:orders)
+    .group(:state)
+    .select("users.state, count(orders.id) AS state_count")
+    .order("state_count DESC")
+    .map(&:state)
   end
 
   def enabled_toggle

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,14 @@
 <div id="statistics">
+  Statistics!
   <p>Top Merchants by Quantity: 
-    <%= @top_merchants_by_quantity.each do |merchant| %>
+    <% @top_merchants_by_quantity.each do |merchant| %>
+    <ul>
+      <li><%= merchant.name %></li>
+    </ul>
+    <% end %>
+  </p>
+  <p>Top Merchants by Price: 
+    <% @top_merchants_by_price.each do |merchant| %>
     <ul>
       <li><%= merchant.name %></li>
     </ul>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,8 +14,15 @@
     </ul>
     <% end %>
   </p>
-  <p>Merchants with Fastest Fulfillment Time:
+  <p>Merchants with Fastest Fulfillment Times:
     <% @top_merchants_by_time.each do |merchant| %>
+    <ul>
+      <li><%= merchant.name %></li>
+    </ul>
+    <% end %>
+  </p>
+  <p>Merchants with Slowest Fulfillment Times:
+    <% @bottom_merchants_by_time.each do |merchant| %>
     <ul>
       <li><%= merchant.name %></li>
     </ul>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -42,6 +42,13 @@
     </ul>
     <% end %>
   </p>
+  <p>Biggest Orders by Quantity of Items:
+    <% @biggest_orders.each do |order| %>
+    <ul>
+      <li>Order #<%= order.id %></li>
+    </ul>
+    <% end %>
+  </p>
 </div>
 
 <% @merchants.each do |merchant| %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -14,6 +14,13 @@
     </ul>
     <% end %>
   </p>
+  <p>Merchants with Fastest Fulfillment Time:
+    <% @top_merchants_by_time.each do |merchant| %>
+    <ul>
+      <li><%= merchant.name %></li>
+    </ul>
+    <% end %>
+  </p>
 </div>
 
 <% @merchants.each do |merchant| %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -28,6 +28,13 @@
     </ul>
     <% end %>
   </p>
+  <p>Top 3 States with Most Orders:
+    <% @top_states.each do |state| %>
+    <ul>
+      <li><%= state %></li>
+    </ul>
+    <% end %>
+  </p>
 </div>
 
 <% @merchants.each do |merchant| %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,5 @@
 <div id="statistics">
-  <p>Top Merchants by Quantity:
+  <p>Top Merchants by Quantity: 
     <%= @top_merchants_by_quantity.each do |merchant| %>
     <ul>
       <li><%= merchant.name %></li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,13 @@
+<div id="statistics">
+  <p>Top Merchants by Quantity:
+    <%= @top_merchants_by_quantity.each do |merchant| %>
+    <ul>
+      <li><%= merchant.name %></li>
+    </ul>
+    <% end %>
+  </p>
+</div>
+
 <% @merchants.each do |merchant| %>
     <ul id="merchant-<%= merchant.id %>">
       <li><%= merchant.name %></li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -35,6 +35,13 @@
     </ul>
     <% end %>
   </p>
+  <p>Top 3 Cities with Most Orders:
+    <% @top_cities.each do |city, state| %>
+    <ul>
+      <li><%= city %>, <%= state %></li>
+    </ul>
+    <% end %>
+  </p>
 </div>
 
 <% @merchants.each do |merchant| %>

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -79,8 +79,10 @@ describe 'as a visitor' do
       
       fastest_merchants = "\n#{merchant_2.name}\n#{merchant_1.name}\n#{merchant_3.name}"
       
+      visit merchants_path
+      
       within "#statistics" do
-        expect(page).to have_content("Top Merchants With Fastets Fulfillment Times:#{fastest_merchants}")
+        expect(page).to have_content("Merchants With Fastest Fulfillment Time:#{fastest_merchants}")
       end
       
     end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -67,22 +67,26 @@ describe 'as a visitor' do
       create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.hour.ago)
       
       merchant_2 = create(:merchant)
-      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.hours.ago)
-      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.hours.ago)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_2), created_at: 2.hours.ago)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_2), created_at: 2.hours.ago)
       
       merchant_3 = create(:merchant)
-      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.days.ago)
-      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 3.days.ago)
-      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 3.days.ago)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 2.days.ago)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 3.days.ago)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 3.days.ago)
       
       merchant_4 = create(:merchant)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_4), created_at: 4.days.ago)
       
       fastest_merchants = "\n#{merchant_2.name}\n#{merchant_1.name}\n#{merchant_3.name}"
+      slowest_merchants = "\n#{merchant_4.name}\n#{merchant_3.name}\n#{merchant_1.name}"
       
       visit merchants_path
       
       within "#statistics" do
-        expect(page).to have_content("Merchants With Fastest Fulfillment Time:#{fastest_merchants}")
+        expect(page).to have_content("Merchants with Fastest Fulfillment Times:#{fastest_merchants}")
+        expect(page).to have_content("Merchants with Slowest Fulfillment Times:#{slowest_merchants}")
+        
       end
       
     end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -169,5 +169,32 @@ describe 'as a visitor' do
         expect(page).to_not have_content(user_3.city)
       end
     end
+    it 'should show stats for the top 3 biggest order by quantity of items' do
+      order_1 = create(:fulfilled_order)
+      create(:fulfilled_order_item, order: order_1)
+      create(:fulfilled_order_item, order: order_1)
+      
+      order_2 = create(:fulfilled_order)
+      4.times do
+        create(:fulfilled_order_item, order: order_2)
+      end
+      
+      order_3 = create(:fulfilled_order)
+      3.times do
+        create(:fulfilled_order_item, order: order_3)
+      end
+      
+      order_4 = create(:fulfilled_order)
+      create(:fulfilled_order_item, order: order_4)
+      
+      top_orders = "\nOrder ##{order_2.id}\nOrder ##{order_3.id}\nOrder ##{order_1.id}"
+      
+      visit merchants_path
+      
+      within "#statistics" do
+        expect(page).to have_content("Biggest Orders by Quantity of Items: #{top_orders}")
+        expect(page).to_not have_content("Order ##{order_4.id}")
+      end
+    end
   end
 end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -168,7 +168,6 @@ describe 'as a visitor' do
         expect(page).to_not have_content(user_4.city)
         expect(page).to_not have_content(user_3.city)
       end
-      
     end
   end
 end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -30,24 +30,26 @@ describe 'as a visitor' do
     
     it 'should show an area with statistics showing top merchants by price and quantity' do
       merchant_1 = create(:merchant)
-      item_1 = create(:item, user: merchant_1)
-      item_2 = create(:item, user: merchant_1)
-      item_3 = create(:item, user: merchant_1)
-      create(:fulfilled_order_item, item: item_1)
-      create(:fulfilled_order_item, item: item_2)
-      create(:fulfilled_order_item, item: item_3)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1))
       
       merchant_2 = create(:merchant)
-      item_6 = create(:item, user: merchant_2)
-      create(:fulfilled_order_item, item: item_6)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_2))
+      create(:fulfilled_order_item, item: create(:item, user: merchant_2))
       
       merchant_3 = create(:merchant)
       
       merchant_4 = create(:merchant)
-      item_4 = create(:item, user: merchant_4)
-      item_5 = create(:item, user: merchant_4)
-      create(:fulfilled_order_item, item: item_4)
-      create(:fulfilled_order_item, item: item_5)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+      create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+      create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+      create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
+      create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
+      
+      merchant_5 = create(:merchant)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_5))
       
       visit merchants_path
       
@@ -56,7 +58,7 @@ describe 'as a visitor' do
       # end
       # 
       within "#statistics" do
-        expect(page).to have_content("Top Merchants by Quantity: \n#{merchant_1.name}\n#{merchant_4.name}\n#{merchant_2.name}")
+        expect(page).to have_content("Top Merchants by Quantity:\n#{merchant_1.name}\n#{merchant_4.name}\n#{merchant_2.name}")
       end
       
     end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -91,28 +91,38 @@ describe 'as a visitor' do
     
     it 'should show stats for top 3 states and cities where orders were shipped' do
       user_1 = create(:user, state: 'CO')
-      create(:order, user: user_1)
-      create(:order, user: user_1)
+      create(:fulfilled_order, user: user_1)
+      create(:fulfilled_order, user: user_1)
       
       user_2 = create(:user, state: 'HI')
-      create(:order, user: user_2)
-      create(:order, user: user_2)
-      create(:order, user: user_2)
+      create(:fulfilled_order, user: user_2)
+      create(:fulfilled_order, user: user_2)
+      create(:fulfilled_order, user: user_2)
       
       user_3 = create(:user, state: 'CA')
-      create(:order, user: user_3)
+      create(:fulfilled_order, user: user_3)
       
       user_4 = create(:user, state: 'NY')
       
       user_5 = create(:user, state: 'HI')
-      create(:order, user: user_5)
+      create(:fulfilled_order, user: user_5)
+      
+      user_6 = create(:user, state: 'AK')
+      5.times do
+        create(:fulfilled_order, user: user_6, status: 0 )
+      end
+      
+      user_7 = create(:user, state: 'AK')
+      5.times do
+        create(:fulfilled_order, user: user_7, status: 2)
+      end
       
       top_states = "\n#{user_2.state}\n#{user_1.state}\n#{user_3.state}"
       
       visit merchants_path 
       
       within "#statistics" do
-        expect(page).to have_content("Top 3 States with Most Orders: #{top_states}")
+        expect(page).to have_content("Top 3 States with Most Orders:#{top_states}")
         expect(page).to_not have_content(user_4.state)
       end
       

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -109,6 +109,8 @@ describe 'as a visitor' do
       
       top_states = "\n#{user_2.state}\n#{user_1.state}\n#{user_3.state}"
       
+      visit merchants_path 
+      
       within "#statistics" do
         expect(page).to have_content("Top 3 States with Most Orders: #{top_states}")
         expect(page).to_not have_content(user_4.state)

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -27,5 +27,36 @@ describe 'as a visitor' do
       expect(page).to have_content(user_3.state)
       expect(page).to have_content(user_3.created_at)
     end
+    
+    it 'should show an area with statistics showing top merchants by price and quantity' do
+      merchant_1 = create(:merchant)
+      item_1 = create(:item, user: merchant_1)
+      item_2 = create(:item, user: merchant_1)
+      item_3 = create(:item, user: merchant_1)
+      create(:fulfilled_order_item, item: item_1)
+      create(:fulfilled_order_item, item: item_2)
+      create(:fulfilled_order_item, item: item_3)
+      
+      merchant_2 = create(:merchant)
+      item_6 = create(:item, user: merchant_2)
+      create(:fulfilled_order_item, item: item_6)
+      
+      merchant_3 = create(:merchant)
+      
+      merchant_4 = create(:merchant)
+      item_4 = create(:item, user: merchant_4)
+      item_5 = create(:item, user: merchant_4)
+      create(:fulfilled_order_item, item: item_4)
+      create(:fulfilled_order_item, item: item_5)
+      
+      # within "#statistics" do
+      #   expect(page).to have_content("Top Merchants by Price: ")
+      # end
+      # 
+      within "#statistics" do
+        expect(page).to have_content("Top Merchants by Quantity: \n#{merchant_1.name}\n#{merchant_4.name}\n#{merchant_2.name}")
+      end
+      
+    end
   end
 end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -57,8 +57,30 @@ describe 'as a visitor' do
       
       within "#statistics" do
         expect(page).to have_content("Top Merchants by Quantity:#{top_merchants_quantity}")
-        
         expect(page).to have_content("Top Merchants by Price:#{top_merchants_price}")
+        expect(page).to_not have_content(merchant_3.name)
+      end
+    end
+    it 'should show stats about top and bottom three merchants in terms of fulfillment time' do
+      merchant_1 = create(:merchant)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.day.ago)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.hour.ago)
+      
+      merchant_2 = create(:merchant)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.hours.ago)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.hours.ago)
+      
+      merchant_3 = create(:merchant)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.days.ago)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 3.days.ago)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 3.days.ago)
+      
+      merchant_4 = create(:merchant)
+      
+      fastest_merchants = "\n#{merchant_2.name}\n#{merchant_1.name}\n#{merchant_3.name}"
+      
+      within "#statistics" do
+        expect(page).to have_content("Top Merchants With Fastets Fulfillment Times:#{fastest_merchants}")
       end
       
     end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -186,14 +186,29 @@ describe 'as a visitor' do
       
       order_4 = create(:fulfilled_order)
       create(:fulfilled_order_item, order: order_4)
+      5.times do
+        create(:unfulfilled_order_item, order: order_4)
+      end
+      
+      order_5 = create(:order)
+      5.times do
+        create(:fulfilled_order_item, order: order_5)
+      end
+      
+      order_6 = create(:cancelled_order)
+      5.times do
+        create(:fulfilled_order_item, order: order_6)
+      end
       
       top_orders = "\nOrder ##{order_2.id}\nOrder ##{order_3.id}\nOrder ##{order_1.id}"
       
       visit merchants_path
       
       within "#statistics" do
-        expect(page).to have_content("Biggest Orders by Quantity of Items: #{top_orders}")
+        expect(page).to have_content("Biggest Orders by Quantity of Items:#{top_orders}")
         expect(page).to_not have_content("Order ##{order_4.id}")
+        expect(page).to_not have_content("Order ##{order_5.id}")
+        expect(page).to_not have_content("Order ##{order_6.id}")
       end
     end
   end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -90,10 +90,30 @@ describe 'as a visitor' do
     end
     
     it 'should show stats for top 3 states and cities where orders were shipped' do
-      merchant_1 = create(:merchant)
-      merchant_2 = create(:merchant)
-      merchant_3 = create(:merchant)
-      merchant_4 = create(:merchant)
+      user_1 = create(:user, state: 'CO')
+      create(:order, user: user_1)
+      create(:order, user: user_1)
+      
+      user_2 = create(:user, state: 'HI')
+      create(:order, user: user_2)
+      create(:order, user: user_2)
+      create(:order, user: user_2)
+      
+      user_3 = create(:user, state: 'CA')
+      create(:order, user: user_3)
+      
+      user_4 = create(:user, state: 'NY')
+      
+      user_5 = create(:user, state: 'HI')
+      create(:order, user: user_5)
+      
+      top_states = "\n#{user_2.state}\n#{user_1.state}\n#{user_3.state}"
+      
+      within "#statistics" do
+        expect(page).to have_content("Top 3 States with Most Orders: #{top_states}")
+        expect(page).to_not have_content(user_4.state)
+      end
+      
     end
   end
 end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -49,6 +49,8 @@ describe 'as a visitor' do
       create(:fulfilled_order_item, item: item_4)
       create(:fulfilled_order_item, item: item_5)
       
+      visit merchants_path
+      
       # within "#statistics" do
       #   expect(page).to have_content("Top Merchants by Price: ")
       # end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -30,10 +30,9 @@ describe 'as a visitor' do
     
     it 'should show an area with statistics showing top merchants by price and quantity' do
       merchant_1 = create(:merchant)
-      create(:fulfilled_order_item, item: create(:item, user: merchant_1))
-      create(:fulfilled_order_item, item: create(:item, user: merchant_1))
-      create(:fulfilled_order_item, item: create(:item, user: merchant_1))
-      create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+      4.times do
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
+      end
       
       merchant_2 = create(:merchant)
       create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 4000)
@@ -42,9 +41,9 @@ describe 'as a visitor' do
       merchant_3 = create(:merchant)
       
       merchant_4 = create(:merchant)
-      create(:fulfilled_order_item, item: create(:item, user: merchant_4))
-      create(:fulfilled_order_item, item: create(:item, user: merchant_4))
-      create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+      3.times do
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
+      end
       create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
       create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
       

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -36,8 +36,8 @@ describe 'as a visitor' do
       create(:fulfilled_order_item, item: create(:item, user: merchant_1))
       
       merchant_2 = create(:merchant)
-      create(:fulfilled_order_item, item: create(:item, user: merchant_2))
-      create(:fulfilled_order_item, item: create(:item, user: merchant_2))
+      create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 4000)
+      create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 5000)
       
       merchant_3 = create(:merchant)
       
@@ -49,16 +49,17 @@ describe 'as a visitor' do
       create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
       
       merchant_5 = create(:merchant)
-      create(:fulfilled_order_item, item: create(:item, user: merchant_5))
+      create(:fulfilled_order_item, item: create(:item, user: merchant_5), order_price: 10000)
+      
+      top_merchants_quantity = "\n#{merchant_1.name}\n#{merchant_4.name}\n#{merchant_2.name}"
+      top_merchants_price = "\n#{merchant_5.name}\n#{merchant_2.name}\n#{merchant_1.name}"
       
       visit merchants_path
       
-      # within "#statistics" do
-      #   expect(page).to have_content("Top Merchants by Price: ")
-      # end
-      # 
       within "#statistics" do
-        expect(page).to have_content("Top Merchants by Quantity:\n#{merchant_1.name}\n#{merchant_4.name}\n#{merchant_2.name}")
+        expect(page).to have_content("Top Merchants by Quantity:#{top_merchants_quantity}")
+        
+        expect(page).to have_content("Top Merchants by Price:#{top_merchants_price}")
       end
       
     end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -89,7 +89,7 @@ describe 'as a visitor' do
       end
     end
     
-    it 'should show stats for top 3 states and cities where orders were shipped' do
+    it 'should show stats for top 3 states where orders were shipped' do
       user_1 = create(:user, state: 'CO')
       create(:fulfilled_order, user: user_1)
       create(:fulfilled_order, user: user_1)
@@ -124,6 +124,49 @@ describe 'as a visitor' do
       within "#statistics" do
         expect(page).to have_content("Top 3 States with Most Orders:#{top_states}")
         expect(page).to_not have_content(user_4.state)
+      end
+    end
+    it 'should show stats for top 3 cities where orders were shipped' do
+      user_1 = create(:user, city: 'Springfield', state: 'CO')
+      create(:fulfilled_order, user: user_1)
+      create(:fulfilled_order, user: user_1)
+      
+      user_2 = create(:user, city: 'Honolulu', state: 'HI')
+      4.times do
+        create(:fulfilled_order, user: user_2)
+      end
+      
+      user_3 = create(:user, city: 'Claremont', state: 'CA')
+      create(:fulfilled_order, user: user_3)
+      
+      user_4 = create(:user, city: 'New York City', state: 'NY')
+      
+      user_5 = create(:user, city: 'Honolulu', state: 'HI')
+      create(:fulfilled_order, user: user_5)
+      
+      user_6 = create(:user, city: 'Fairbanks', state: 'AK')
+      6.times do
+        create(:fulfilled_order, user: user_6, status: 0 )
+      end
+      
+      user_7 = create(:user, city: 'Fairbanks', state: 'AK')
+      6.times do
+        create(:fulfilled_order, user: user_7, status: 2)
+      end
+      
+      user_8 = create(:user, city: 'Springfield', state: 'MI')
+      create(:fulfilled_order, user: user_8)
+      create(:fulfilled_order, user: user_8)
+      create(:fulfilled_order, user: user_8)
+      
+      top_cities = "\n#{user_2.city}, #{user_2.state}\n#{user_8.city}, #{user_8.state}\n#{user_1.city}, #{user_1.state}"
+      
+      visit merchants_path 
+      
+      within "#statistics" do
+        expect(page).to have_content("Top 3 Cities with Most Orders:#{top_cities}")
+        expect(page).to_not have_content(user_4.city)
+        expect(page).to_not have_content(user_3.city)
       end
       
     end

--- a/spec/features/merchant_index_page_spec.rb
+++ b/spec/features/merchant_index_page_spec.rb
@@ -86,9 +86,14 @@ describe 'as a visitor' do
       within "#statistics" do
         expect(page).to have_content("Merchants with Fastest Fulfillment Times:#{fastest_merchants}")
         expect(page).to have_content("Merchants with Slowest Fulfillment Times:#{slowest_merchants}")
-        
       end
-      
+    end
+    
+    it 'should show stats for top 3 states and cities where orders were shipped' do
+      merchant_1 = create(:merchant)
+      merchant_2 = create(:merchant)
+      merchant_3 = create(:merchant)
+      merchant_4 = create(:merchant)
     end
   end
 end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe OrderItem, type: :model do
     it { should validate_presence_of(:item_id)}
     it { should validate_presence_of(:quantity)}
     it { should validate_presence_of(:order_price)}
-    it { should validate_presence_of(:fulfilled)}
+    it { should validate_inclusion_of(:fulfilled).in_array([true, false])}
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe Order, type: :model do
         
         order_4 = create(:fulfilled_order)
         create(:fulfilled_order_item, order: order_4)
+        5.times do
+          create(:unfulfilled_order_item, order: order_4)
+        end
+        
+        order_5 = create(:order)
+        5.times do
+          create(:fulfilled_order_item, order: order_5)
+        end
+        
+        order_6 = create(:cancelled_order)
+        5.times do
+          create(:fulfilled_order_item, order: order_6)
+        end
         
         orders = [order_2, order_3, order_1]
         

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -11,5 +11,32 @@ RSpec.describe Order, type: :model do
     it { should validate_presence_of(:status)}
     it { should validate_presence_of(:user_id)}
   end
+  
+  describe 'Class Methods' do
+    describe '.biggest_orders' do
+      it 'should return the top 3 orders by quantity of items' do
+        order_1 = create(:fulfilled_order)
+        create(:fulfilled_order_item, order: order_1)
+        create(:fulfilled_order_item, order: order_1)
+        
+        order_2 = create(:fulfilled_order)
+        4.times do
+          create(:fulfilled_order_item, order: order_2)
+        end
+        
+        order_3 = create(:fulfilled_order)
+        3.times do
+          create(:fulfilled_order_item, order: order_3)
+        end
+        
+        order_4 = create(:fulfilled_order)
+        create(:fulfilled_order_item, order: order_4)
+        
+        orders = [order_2, order_3, order_1]
+        
+        expect(Order.biggest_orders).to eq(orders)
+      end
+    end
+  end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -108,6 +108,28 @@ RSpec.describe User, type: :model do
         expect(User.merchants_by_price).to eq([merchant_5, merchant_2, merchant_1])
       end
     end
+    describe '.merchants_by_time' do
+      it 'should return merchants sorted by average fulfillment time descending' do
+        merchant_1 = create(:merchant)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.day.ago)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.hour.ago)
+        
+        merchant_2 = create(:merchant)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.hours.ago)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.hours.ago)
+        
+        merchant_3 = create(:merchant)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.days.ago)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 3.days.ago)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 3.days.ago)
+        
+        merchant_4 = create(:merchant)
+        
+        sorted_merchants = [merchant_2, merchant_1, merchant_3, merchant_4]
+        
+        expect(User.merchants_by_time).to eq(sorted_merchants)
+      end
+    end
   end
   
   describe 'Instance Methods' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -82,6 +82,33 @@ RSpec.describe User, type: :model do
         expect(User.merchants_by_quantity).to eq([merchant_1, merchant_4, merchant_2])
       end
     end
+    describe '.merchants_by_price' do
+      it 'should return top three merchants by total price of items sold' do
+        merchant_1 = create(:merchant)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        
+        merchant_2 = create(:merchant)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 4000)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 5000)
+        
+        merchant_3 = create(:merchant)
+        
+        merchant_4 = create(:merchant)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+        create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
+        create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
+        
+        merchant_5 = create(:merchant)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_5), order_price: 10000)
+        
+        expect(User.merchants_by_price).to eq([merchant_5, merchant_2, merchant_1])
+      end
+    end
   end
   
   describe 'Instance Methods' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -109,21 +109,22 @@ RSpec.describe User, type: :model do
       end
     end
     describe '.merchants_by_time' do
-      it 'should return merchants sorted by average fulfillment time descending' do
+      it 'should return merchants sorted by average fulfillment time ascending' do
         merchant_1 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.day.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.hour.ago)
         
         merchant_2 = create(:merchant)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.hours.ago)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.hours.ago)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_2), created_at: 2.hours.ago)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_2), created_at: 2.hours.ago)
         
         merchant_3 = create(:merchant)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 2.days.ago)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 3.days.ago)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 3.days.ago)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 2.days.ago)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 3.days.ago)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 3.days.ago)
         
         merchant_4 = create(:merchant)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4), created_at: 4.days.ago)
         
         sorted_merchants = [merchant_2, merchant_1, merchant_3, merchant_4]
         

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,16 +66,20 @@ RSpec.describe User, type: :model do
         create(:fulfilled_order_item, item: item_3)
         
         merchant_2 = create(:merchant)
-        item_6 = create(:item, user: merchant_2)
-        create(:fulfilled_order_item, item: item_6)
+        item_8 = create(:item, user: merchant_2)
+        create(:fulfilled_order_item, item: item_8)
         
         merchant_3 = create(:merchant)
         
         merchant_4 = create(:merchant)
         item_4 = create(:item, user: merchant_4)
         item_5 = create(:item, user: merchant_4)
+        item_6 = create(:item, user: merchant_4)
+        item_7 = create(:item, user: merchant_4)
         create(:fulfilled_order_item, item: item_4)
         create(:fulfilled_order_item, item: item_5)
+        create(:unfulfilled_order_item, item: item_6)
+        create(:unfulfilled_order_item, item: item_7)
         
         expect(User.merchants_by_quantity).to eq([merchant_1, merchant_4, merchant_2])
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,10 +58,9 @@ RSpec.describe User, type: :model do
     describe '.merchants_by_quantity' do
       it 'should return the top three merchants by quantity of items sold' do
         merchant_1 = create(:merchant)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        4.times do
+          create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        end
         
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2))
@@ -70,14 +69,19 @@ RSpec.describe User, type: :model do
         merchant_3 = create(:merchant)
         
         merchant_4 = create(:merchant)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+        3.times do
+          create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+        end
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         
         merchant_5 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_5))
+        
+        merchant_6 = create(:merchant, enabled: false)
+        5.times do
+          create(:fulfilled_order_item, item: create(:item, user: merchant_6))
+        end
         
         expect(User.merchants_by_quantity).to eq([merchant_1, merchant_4, merchant_2])
       end
@@ -105,6 +109,11 @@ RSpec.describe User, type: :model do
         merchant_5 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_5), order_price: 10000)
         
+        merchant_6 = create(:merchant, enabled: false)
+        5.times do
+          create(:fulfilled_order_item, item: create(:item, user: merchant_6), order_price: 10000)
+        end
+        
         expect(User.merchants_by_price).to eq([merchant_5, merchant_2, merchant_1])
       end
     end
@@ -113,6 +122,7 @@ RSpec.describe User, type: :model do
         merchant_1 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.day.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.hour.ago)
+        create(:unfulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.minute.ago)
         
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), created_at: 2.hours.ago)
@@ -125,6 +135,10 @@ RSpec.describe User, type: :model do
         
         merchant_4 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_4), created_at: 4.days.ago)
+        
+        merchant_5 = create(:merchant, enabled: false)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_5), created_at: 1.minute.ago)
+        
         
         sorted_merchants = [merchant_2, merchant_1, merchant_3, merchant_4]
         

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -148,21 +148,31 @@ RSpec.describe User, type: :model do
     describe '.top_states' do
       it 'should return the top three states where any orders were shipped' do
         user_1 = create(:user, state: 'CO')
-        create(:order, user: user_1)
-        create(:order, user: user_1)
+        create(:fulfilled_order, user: user_1)
+        create(:fulfilled_order, user: user_1)
         
         user_2 = create(:user, state: 'HI')
-        create(:order, user: user_2)
-        create(:order, user: user_2)
-        create(:order, user: user_2)
+        create(:fulfilled_order, user: user_2)
+        create(:fulfilled_order, user: user_2)
+        create(:fulfilled_order, user: user_2)
         
         user_3 = create(:user, state: 'CA')
-        create(:order, user: user_3)
+        create(:fulfilled_order, user: user_3)
         
         user_4 = create(:user, state: 'NY')
         
         user_5 = create(:user, state: 'HI')
-        create(:order, user: user_5)
+        create(:fulfilled_order, user: user_5)
+        
+        user_6 = create(:user, state: 'AK')
+        5.times do
+          create(:fulfilled_order, user: user_6, status: 0 )
+        end
+        
+        user_7 = create(:user, state: 'AK')
+        5.times do
+          create(:fulfilled_order, user: user_7, status: 2)
+        end
         
         states = ['HI', 'CO', 'CA']
         

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -179,6 +179,45 @@ RSpec.describe User, type: :model do
         expect(User.top_states).to eq(states)
       end
     end
+    describe '.top_cities' do
+      it 'should return the top three cities with the most orders shipped' do
+        user_1 = create(:user, city: 'Springfield', state: 'CO')
+        create(:fulfilled_order, user: user_1)
+        create(:fulfilled_order, user: user_1)
+        
+        user_2 = create(:user, city: 'Honolulu', state: 'HI')
+        4.times do
+          create(:fulfilled_order, user: user_2)
+        end
+        
+        user_3 = create(:user, city: 'Claremont', state: 'CA')
+        create(:fulfilled_order, user: user_3)
+        
+        user_4 = create(:user, city: 'New York City', state: 'NY')
+        
+        user_5 = create(:user, city: 'Honolulu', state: 'HI')
+        create(:fulfilled_order, user: user_5)
+        
+        user_6 = create(:user, city: 'Fairbanks', state: 'AK')
+        6.times do
+          create(:fulfilled_order, user: user_6, status: 0 )
+        end
+        
+        user_7 = create(:user, city: 'Fairbanks', state: 'AK')
+        6.times do
+          create(:fulfilled_order, user: user_7, status: 2)
+        end
+        
+        user_8 = create(:user, city: 'Springfield', state: 'MI')
+        create(:fulfilled_order, user: user_8)
+        create(:fulfilled_order, user: user_8)
+        create(:fulfilled_order, user: user_8)
+        
+        cities = [['Honolulu', 'HI'], ['Springfield', 'MI'], ['Springfield', 'CO']]
+        
+        expect(User.top_cities).to eq(cities)
+      end
+    end
   end
   
   describe 'Instance Methods' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,7 +54,36 @@ RSpec.describe User, type: :model do
         expect(User.default_users).to eq([user_1, user_2, user_3, user_4])
       end
     end
-    describe '.enabled_toggle' do
+
+    describe '.merchants_by_quantity' do
+      it 'should return the top three merchants by quantity of items sold' do
+        merchant_1 = create(:merchant)
+        item_1 = create(:item, user: merchant_1)
+        item_2 = create(:item, user: merchant_1)
+        item_3 = create(:item, user: merchant_1)
+        create(:fulfilled_order_item, item: item_1)
+        create(:fulfilled_order_item, item: item_2)
+        create(:fulfilled_order_item, item: item_3)
+        
+        merchant_2 = create(:merchant)
+        item_6 = create(:item, user: merchant_2)
+        create(:fulfilled_order_item, item: item_6)
+        
+        merchant_3 = create(:merchant)
+        
+        merchant_4 = create(:merchant)
+        item_4 = create(:item, user: merchant_4)
+        item_5 = create(:item, user: merchant_4)
+        create(:fulfilled_order_item, item: item_4)
+        create(:fulfilled_order_item, item: item_5)
+        
+        expect(User.merchants_by_quantity).to eq([merchant_1, merchant_4, merchant_2])
+      end
+    end
+  end
+  
+  describe 'Instance Methods' do
+    describe '#enabled_toggle' do
       it 'toggles a user between enabled and disabled states' do
         user = User.create(name: 'User One', street: 'Street One', city: 'City One', state: 'State1',
           zip: 'ZIP1', email: 'email1@aol.com', password: 'password1', role: 0, enabled: true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,10 +85,10 @@ RSpec.describe User, type: :model do
     describe '.merchants_by_price' do
       it 'should return top three merchants by total price of items sold' do
         merchant_1 = create(:merchant)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
         
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 4000)
@@ -97,9 +97,9 @@ RSpec.describe User, type: :model do
         merchant_3 = create(:merchant)
         
         merchant_4 = create(:merchant)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
-        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,10 +85,9 @@ RSpec.describe User, type: :model do
     describe '.merchants_by_price' do
       it 'should return top three merchants by total price of items sold' do
         merchant_1 = create(:merchant)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
+        4.times do
+          create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
+        end
         
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 4000)
@@ -97,9 +96,9 @@ RSpec.describe User, type: :model do
         merchant_3 = create(:merchant)
         
         merchant_4 = create(:merchant)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
-        create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
+        3.times do
+          create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
+        end
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,28 +58,26 @@ RSpec.describe User, type: :model do
     describe '.merchants_by_quantity' do
       it 'should return the top three merchants by quantity of items sold' do
         merchant_1 = create(:merchant)
-        item_1 = create(:item, user: merchant_1)
-        item_2 = create(:item, user: merchant_1)
-        item_3 = create(:item, user: merchant_1)
-        create(:fulfilled_order_item, item: item_1)
-        create(:fulfilled_order_item, item: item_2)
-        create(:fulfilled_order_item, item: item_3)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_1))
         
         merchant_2 = create(:merchant)
-        item_8 = create(:item, user: merchant_2)
-        create(:fulfilled_order_item, item: item_8)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_2))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_2))
         
         merchant_3 = create(:merchant)
         
         merchant_4 = create(:merchant)
-        item_4 = create(:item, user: merchant_4)
-        item_5 = create(:item, user: merchant_4)
-        item_6 = create(:item, user: merchant_4)
-        item_7 = create(:item, user: merchant_4)
-        create(:fulfilled_order_item, item: item_4)
-        create(:fulfilled_order_item, item: item_5)
-        create(:unfulfilled_order_item, item: item_6)
-        create(:unfulfilled_order_item, item: item_7)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+        create(:fulfilled_order_item, item: create(:item, user: merchant_4))
+        create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
+        create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
+        
+        merchant_5 = create(:merchant)
+        create(:fulfilled_order_item, item: create(:item, user: merchant_5))
         
         expect(User.merchants_by_quantity).to eq([merchant_1, merchant_4, merchant_2])
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -145,6 +145,30 @@ RSpec.describe User, type: :model do
         expect(User.merchants_by_time).to eq(sorted_merchants)
       end
     end
+    describe '.top_states' do
+      it 'should return the top three states where any orders were shipped' do
+        user_1 = create(:user, state: 'CO')
+        create(:order, user: user_1)
+        create(:order, user: user_1)
+        
+        user_2 = create(:user, state: 'HI')
+        create(:order, user: user_2)
+        create(:order, user: user_2)
+        create(:order, user: user_2)
+        
+        user_3 = create(:user, state: 'CA')
+        create(:order, user: user_3)
+        
+        user_4 = create(:user, state: 'NY')
+        
+        user_5 = create(:user, state: 'HI')
+        create(:order, user: user_5)
+        
+        states = ['HI', 'CO', 'CA']
+        
+        expect(User.top_states).to eq(states)
+      end
+    end
   end
   
   describe 'Instance Methods' do


### PR DESCRIPTION
Completes User Story 46: Merchant Index Page Statistics

- Adds a Statistics area to the merchants index page with the following content
- Top three merchants who sold the most by price
  - This takes into account that the merchant is enabled and the order_item is fulfilled
- Top three merchants who sold the most by quantity
  - This takes into account that the merchant is enabled and the order_item is fulfilled
- Fastest 3 merchants at fulfilling items
- Slowest 3 merchants at fulfilling items
  - Fastest and Slowest are both taken from the same method: `merchants_by_time` that returns a sorted array of merchants by the time it takes them to fulfill an item. I add logic in the controller to limit it to three (and reverse it for slowest), but can also just push that logic to the model if that would be better. 
  - Takes into account that the merchant is enabled and that the order_items are fulfilled
- Top 3 states where any orders were shipped
  - Takes into account that the order status is 1, fulfilled.
  - Does use a Ruby method (`.map`) to get the specific info we want (the states). Not sure if there is a better way to do this. 
- Top 3 cities where any orders were shipped (taking state into account so e.g. all 'Springfields' in all states are not lumped together)
  - Takes into account that the order status is 1, fulfilled.
  -Does use a Ruby method (`.map`) to get the specific info we want (the cities and states). Not sure if there is a better way to do this. 
- Top 3 biggest orders by quantity of items
  - This is the only one that is not in the User model - this is in the Order model. 
  - Takes into account that the status is 1 - fulfilled.
  - Takes into account that the order_items are fulfilled
- All tests passing

Closes #22 