### PR TITLE
Admin Disables & Enables a User, Stories 63 & 64

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,22 +8,26 @@ class Admin::UsersController < ApplicationController
   def show
     @merchant = User.find(params[:id])
   end
-  
+
   def create
 
   end
 
   def update
     user = User.find(params[:id])
-    if user[:enabled] == true
+    if user.enabled == true
       user.update(:enabled => false)
       flash[:notice] = "#{user.name} is now disabled"
     elsif
-      user[:enabled] == false
+      user.enabled == false
       user.update(:enabled => true)
       flash[:notice] = "#{user.name} is now enabled"
     end
-    redirect_to "/merchants"
+    if user.role == "merchant"
+      redirect_to "/merchants"
+    else
+      redirect_to admin_users_path
+    end
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,4 @@ class User < ApplicationRecord
     where(role: :default)
   end
 
-  def enabled_toggle
-    enabled ? self.update(enabled: false) : self.update(enabled: true)
-  end
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,10 +3,10 @@
     <ul>
       <li><%= link_to user.name, admin_user_path(user) %></li>
       <li><%= user.created_at %></li>
-      <% if user.enabled? %>
-        <li><%= button_to 'Disable', admin_users_path() %></li>
+      <% if user.enabled %>
+        <li><%= button_to 'disable', admin_user_path(user.id), method: :patch %></li>
       <% else %>
-        <li><%= button_to 'Enable', admin_users_path %></li>
+        <li><%= button_to 'enable', admin_user_path(user.id), method: :patch %></li>
       <% end %>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   resources :carts, only: [:create]
 
   namespace :admin do
-    resources :users, only: [:index, :show]
+    resources :users, only: [:index, :show, :update]
     resources :users, as: :merchants, only: [:index, :show, :update]
   end
 

--- a/spec/features/admin_user_index_page_spec.rb
+++ b/spec/features/admin_user_index_page_spec.rb
@@ -27,26 +27,26 @@ describe 'ADMIN USER INDEX PAGE' do
       within "#user-links-#{user_1.id}" do
         expect(page).to have_link(user_1.name)
         expect(page).to have_content(user_1.created_at)
-        expect(page).to have_button("Disable")
+        expect(page).to have_button("disable")
       end
       within "#user-links-#{user_2.id}" do
         expect(page).to have_link(user_2.name)
         expect(page).to have_content(user_1.created_at)
-        expect(page).to have_button("Disable")
+        expect(page).to have_button("disable")
       end
       within "#user-links-#{user_3.id}" do
         expect(page).to have_link(user_3.name)
         expect(page).to have_content(user_1.created_at)
-        expect(page).to have_button("Enable")
+        expect(page).to have_button("enable")
       end
       within "#user-links-#{user_4.id}" do
         expect(page).to have_link(user_4.name)
         expect(page).to have_content(user_1.created_at)
-        expect(page).to have_button("Disable")
+        expect(page).to have_button("disable")
       end
     end
 
-    xit 'allows me to toggle between enabled and disabled statuses for users' do
+    it 'allows me to enable and disable users' do
       #Defaul Users
       user_1 = User.create(name: 'User One', street: 'Street One', city: 'City One', state: 'State1',
       zip: 'ZIP1', email: 'email1@aol.com', password: 'password1', role: 0, enabled: true)
@@ -59,12 +59,18 @@ describe 'ADMIN USER INDEX PAGE' do
       visit admin_users_path
 
       within "#user-links-#{user_1.id}" do
-        click_button('Disable')
-        expect(page).to have_button("Enable")
-        expect(user_1.enabled).to eq(false)
-        click_button('Enable')
-        expect(page).to have_button("Disable")
-        expect(user_1.enabled).to eq(true)
+        click_button('disable')
+      end
+      within "#user-links-#{user_1.id}" do
+        expect(page).to have_button("enable")
+        comp_user = User.find(user_1.id)
+        expect(comp_user.enabled).to eq(false)
+        click_button('enable')
+      end
+      within "#user-links-#{user_1.id}" do
+        expect(page).to have_button("disable")
+        comp_user = User.find(user_1.id)
+        expect(comp_user.enabled).to eq(true)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,15 +54,5 @@ RSpec.describe User, type: :model do
         expect(User.default_users).to eq([user_1, user_2, user_3, user_4])
       end
     end
-    describe '.enabled_toggle' do
-      it 'toggles a user between enabled and disabled states' do
-        user = User.create(name: 'User One', street: 'Street One', city: 'City One', state: 'State1',
-          zip: 'ZIP1', email: 'email1@aol.com', password: 'password1', role: 0, enabled: true)
-        user.enabled_toggle
-        expect(user.enabled).to eq(false)
-        user.enabled_toggle
-        expect(user.enabled).to eq(true)
-      end
-    end
   end
 end


### PR DESCRIPTION
Allows the admin to enable & disable users chosen from the Admin User Index.

Completes User Stories 63 & 64

All tests passing.