### PR TITLE
Empty cart#42

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -16,5 +16,10 @@ class CartsController < ApplicationController
     session[:cart][item_id_str] += 1
     redirect_to items_path
   end
+  
+  def destroy
+    @cart.empty
+    redirect_to cart_path
+  end
 
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -21,4 +21,8 @@ class Cart
   def cart_count
     @contents.values.sum
   end
+  
+  def empty
+    @contents.clear
+  end
 end

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -12,4 +12,4 @@
   </div>
 <% end  %>
 <p>Grand Total: <%= number_to_currency(@cart.grand_total/100) %></p>
-<%= link_to "Empty Cart", cart_path %>
+<%= link_to "Empty Cart", cart_path, method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   get '/cart', to: "carts#show"
+  delete '/cart', to: "carts#destroy"
   get '/login', to: "sessions#new"
   post '/login', to: "sessions#create"
   get '/register', as: :registration, to: "users#new"

--- a/spec/features/cart_show_page_spec.rb
+++ b/spec/features/cart_show_page_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "When a user visitor visits their cart show page with items in ca
   
   it 'allows a registered user to empty their cart' do
     user = create(:user)
-    allow(ApplicationController).to receive(:current_user).and_return(user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     
     merchant = create(:merchant)
     item_1 = create(:item, user: merchant)

--- a/spec/features/cart_show_page_spec.rb
+++ b/spec/features/cart_show_page_spec.rb
@@ -94,5 +94,42 @@ RSpec.describe "When a user visitor visits their cart show page with items in ca
     expect(page).to_not have_content(item_3.description)
     expect(page).to have_content("Grand Total: $0.00")
   end
-
+  
+  it 'allows a registered user to empty their cart' do
+    user = create(:user)
+    allow(ApplicationController).to receive(:current_user).and_return(user)
+    
+    merchant = create(:merchant)
+    item_1 = create(:item, user: merchant)
+    item_2 = create(:item, user: merchant)
+    item_3 = create(:item, user: merchant)
+    
+    visit items_path
+    within "#item-#{item_1.id}" do
+      click_button 'Add item'
+      click_button 'Add item'
+    end
+    within "#item-#{item_2.id}" do
+      click_button 'Add item'
+    end
+    within "#item-#{item_3.id}" do
+      click_button 'Add item'
+    end
+    
+    visit cart_path
+    
+    click_on "Empty Cart"
+    
+    expect(current_path).to eq(cart_path)
+    within "#nav" do
+      expect(page).to have_content("Cart: 0")
+    end
+    expect(page).to_not have_content(item_1.name)
+    expect(page).to_not have_content(item_2.name)
+    expect(page).to_not have_content(item_3.name)
+    expect(page).to_not have_content(item_1.description)
+    expect(page).to_not have_content(item_2.description)
+    expect(page).to_not have_content(item_3.description)
+    expect(page).to have_content("Grand Total: $0.00")
+  end
 end

--- a/spec/features/cart_show_page_spec.rb
+++ b/spec/features/cart_show_page_spec.rb
@@ -59,5 +59,40 @@ RSpec.describe "When a user visitor visits their cart show page with items in ca
     expect(page).to have_content("Grand Total: #{number_to_currency(subtotal_1 + subtotal_2)}")
     expect(page).to have_link("Empty Cart")
   end
+  
+  it 'allows a visitor to empty their cart' do
+    merchant = create(:merchant)
+    item_1 = create(:item, user: merchant)
+    item_2 = create(:item, user: merchant)
+    item_3 = create(:item, user: merchant)
+    
+    visit items_path
+    within "#item-#{item_1.id}" do
+      click_button 'Add item'
+      click_button 'Add item'
+    end
+    within "#item-#{item_2.id}" do
+      click_button 'Add item'
+    end
+    within "#item-#{item_3.id}" do
+      click_button 'Add item'
+    end
+    
+    visit cart_path
+    
+    click_on "Empty Cart"
+    
+    expect(current_path).to eq(cart_path)
+    within "#nav" do
+      expect(page).to have_content("Cart: 0")
+    end
+    expect(page).to_not have_content(item_1.name)
+    expect(page).to_not have_content(item_2.name)
+    expect(page).to_not have_content(item_3.name)
+    expect(page).to_not have_content(item_1.description)
+    expect(page).to_not have_content(item_2.description)
+    expect(page).to_not have_content(item_3.description)
+    expect(page).to have_content("Grand Total: $0.00")
+  end
 
 end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe Cart do
         expect(cart.cart_count).to eq(3)
       end
     end
+    
+    describe '#empty' do
+      it 'should empty the cart' do
+        cart = Cart.new({'1' => 2, '2' => 1})
+        expect(cart.cart_count).to eq(3)
+        
+        cart.empty
+        
+        expect(cart.cart_count).to eq(0)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Completes User Story 29
- Adds ability to empty the cart
- Works for both visitors and registered users
- Adds `#empty` method to Cart that clears the cart
- Adds new route for delete
- All tests passing
- Fixed merge conflict

Closes #42 