### PR TITLE
Admin makes a merchant#48

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -16,6 +16,12 @@ class Admin::UsersController < ApplicationController
 
   def update
     user = User.find(params[:id])
+    if params[:upgrade]
+      User.find(params[:id]).update(:role => 1)
+      flash[:notice] = 'This user has been upgraded.'
+      redirect_to admin_merchant_path(user)
+      return
+    end
     if user.enabled == true
       user.update(:enabled => false)
       flash[:notice] = "#{user.name} is now disabled"

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -8,6 +8,7 @@
 
 <% if @user_role == 'default' %>
   <%= link_to 'Edit Profile', profile_edit_path %>
+  <%= link_to 'Upgrade to Merchant', admin_merchant_path(@user, :upgrade => true), method: :put %>
 <% elsif @user_role == 'merchant' %>
   <%= link_to 'My Items', dashboard_items_path %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users, only: [:index, :show, :update]
     resources :users, as: :merchants, only: [:index, :show, :update]
+    namespace :merchants do
+      resources :users, as: :merchants, only: [:show]
+    end
   end
 
   namespace :profile do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,9 +22,6 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users, only: [:index, :show, :update]
     resources :users, as: :merchants, only: [:index, :show, :update]
-    namespace :merchants do
-      resources :users, as: :merchants, only: [:show]
-    end
   end
 
   namespace :profile do

--- a/spec/features/admin_user_profile_page_spec.rb
+++ b/spec/features/admin_user_profile_page_spec.rb
@@ -46,4 +46,21 @@ describe 'As an admin user' do
       expect(page).to_not have_content(user_1.password)
     end
   end
+  describe 'I should see a link to upgrade the user account to a merchant account' do
+    it 'should upgrade the user to a merchant' do
+      admin = create(:admin)
+      user_1 = create(:user)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit admin_user_path(user_1)
+
+      expect(page).to have_link('Upgrade to Merchant')
+      click_on('Upgrade to Merchant')
+
+      expect(current_path).to eq(admin_merchant_path(user_1))
+      expect(user_1.role).to eq('merchant')
+      expect(page).to have_content('This user has been upgraded.')
+    end
+  end
 end

--- a/spec/features/admin_user_profile_page_spec.rb
+++ b/spec/features/admin_user_profile_page_spec.rb
@@ -50,6 +50,19 @@ describe 'As an admin user' do
     it 'should upgrade the user to a merchant' do
       admin = create(:admin)
       user_1 = create(:user)
+      user_2 = create(:merchant)
+
+      #confirming default user cannot access path to upgrade a user
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+      visit admin_user_path(user_1)
+      expect(page.status_code).to eq(404)
+      expect(page).to have_content("The page you were looking for doesn't exist")
+
+      #confirming merchant user cannot access path to upgrade a user
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_2)
+      visit admin_user_path(user_1)
+      expect(page.status_code).to eq(404)
+      expect(page).to have_content("The page you were looking for doesn't exist")
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
@@ -63,10 +76,9 @@ describe 'As an admin user' do
       expect(updated_user.role).to eq('merchant')
       expect(page).to have_content('This user has been upgraded.')
 
+      #the upgraded user is now a merchant and can visit their dashboard path
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(updated_user)
-
-      visit(dashboard_path)
-
+      visit dashboard_path
       expect(page).to have_link('My Items')
     end
   end

--- a/spec/features/admin_user_profile_page_spec.rb
+++ b/spec/features/admin_user_profile_page_spec.rb
@@ -61,6 +61,12 @@ describe 'As an admin user' do
       expect(current_path).to eq(admin_merchant_path(user_1))
       expect(user_1.role).to eq('merchant')
       expect(page).to have_content('This user has been upgraded.')
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+      visit(dashboard_path)
+
+      expect(page).to have_link('My Items')
     end
   end
 end

--- a/spec/features/admin_user_profile_page_spec.rb
+++ b/spec/features/admin_user_profile_page_spec.rb
@@ -57,12 +57,13 @@ describe 'As an admin user' do
 
       expect(page).to have_link('Upgrade to Merchant')
       click_on('Upgrade to Merchant')
-
       expect(current_path).to eq(admin_merchant_path(user_1))
-      expect(user_1.role).to eq('merchant')
+
+      updated_user = User.find(user_1.id)
+      expect(updated_user.role).to eq('merchant')
       expect(page).to have_content('This user has been upgraded.')
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(updated_user)
 
       visit(dashboard_path)
 

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -137,7 +137,7 @@ describe 'USER SHOW PAGE' do
       user = create(:user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-      visit(user_path(user))
+      visit(profile_path(user))
 
       expect(page).to_not have_link('Upgrade to Merchant')
     end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -133,5 +133,13 @@ describe 'USER SHOW PAGE' do
       expect(find_field("user[email]").value).to eq(user.email)
       expect(find_field("user[password]").value).to eq(nil)
     end
+    it 'should not see a link to upgrade' do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit(user_path(user))
+
+      expect(page).to_not have_link('Upgrade to Merchant')
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,20 +36,12 @@ RSpec.describe User, type: :model do
     describe '.default_users' do
       it 'returns all default users' do
         #Default Users
-        user_1 = User.create(name: 'User One', street: 'Street One', city: 'City One', state: 'State1',
-        zip: 'ZIP1', email: 'email1@aol.com', password: 'password1', role: 0, enabled: true)
-        user_2 = User.create(name: 'User Two', street: 'Street Two', city: 'City Two', state: 'State2',
-        zip: 'ZIP2', email: 'email2@aol.com', password: 'password2', role: 0, enabled: true)
-        user_3 = User.create(name: 'User Three', street: 'Street Three', city: 'City Three', state: 'State3',
-        zip: 'ZIP3', email: 'email3@aol.com', password: 'password3', role: 0, enabled: false)
-        user_4 = User.create(name: 'User Four', street: 'Street Four', city: 'City Four', state: 'State4',
-        zip: 'ZIP4', email: 'email4@aol.com', password: 'password4', role: 0, enabled: true)
-        #Merchant User
-        user_5 = User.create(name: 'User Five', street: 'Street Five', city: 'City Five', state: 'State5',
-        zip: 'ZIP5', email: 'email5@aol.com', password: 'password5', role: 1, enabled: true)
-        #Admin User
-        user_6 = User.create(name: 'User Six', street: 'Street Six', city: 'City Six', state: 'State6',
-        zip: 'ZIP6', email: 'email6@aol.com', password: 'password6', role: 2, enabled: true)
+        user_1 = create(:user)
+        user_2 = create(:user)
+        user_3 = create(:user)
+        user_4 = create(:user)
+        user_5 = create(:merchant)
+        user_5 = create(:admin)
 
         expect(User.default_users).to eq([user_1, user_2, user_3, user_4])
       end
@@ -61,28 +53,28 @@ RSpec.describe User, type: :model do
         4.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_1))
         end
-        
+
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2))
         create(:fulfilled_order_item, item: create(:item, user: merchant_2))
-        
+
         merchant_3 = create(:merchant)
-        
+
         merchant_4 = create(:merchant)
         3.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_4))
         end
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
-        
+
         merchant_5 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_5))
-        
+
         merchant_6 = create(:merchant, enabled: false)
         5.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_6))
         end
-        
+
         expect(User.merchants_by_quantity).to eq([merchant_1, merchant_4, merchant_2])
       end
     end
@@ -92,28 +84,28 @@ RSpec.describe User, type: :model do
         4.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
         end
-        
+
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 4000)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 5000)
-        
+
         merchant_3 = create(:merchant)
-        
+
         merchant_4 = create(:merchant)
         3.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
         end
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
-        
+
         merchant_5 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_5), order_price: 10000)
-        
+
         merchant_6 = create(:merchant, enabled: false)
         5.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_6), order_price: 10000)
         end
-        
+
         expect(User.merchants_by_price).to eq([merchant_5, merchant_2, merchant_1])
       end
     end
@@ -123,25 +115,25 @@ RSpec.describe User, type: :model do
         create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.day.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.hour.ago)
         create(:unfulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.minute.ago)
-        
+
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), created_at: 2.hours.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), created_at: 2.hours.ago)
-        
+
         merchant_3 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 2.days.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 3.days.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 3.days.ago)
-        
+
         merchant_4 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_4), created_at: 4.days.ago)
-        
+
         merchant_5 = create(:merchant, enabled: false)
         create(:fulfilled_order_item, item: create(:item, user: merchant_5), created_at: 1.minute.ago)
-        
-        
+
+
         sorted_merchants = [merchant_2, merchant_1, merchant_3, merchant_4]
-        
+
         expect(User.merchants_by_time).to eq(sorted_merchants)
       end
     end
@@ -150,32 +142,32 @@ RSpec.describe User, type: :model do
         user_1 = create(:user, state: 'CO')
         create(:fulfilled_order, user: user_1)
         create(:fulfilled_order, user: user_1)
-        
+
         user_2 = create(:user, state: 'HI')
         create(:fulfilled_order, user: user_2)
         create(:fulfilled_order, user: user_2)
         create(:fulfilled_order, user: user_2)
-        
+
         user_3 = create(:user, state: 'CA')
         create(:fulfilled_order, user: user_3)
-        
+
         user_4 = create(:user, state: 'NY')
-        
+
         user_5 = create(:user, state: 'HI')
         create(:fulfilled_order, user: user_5)
-        
+
         user_6 = create(:user, state: 'AK')
         5.times do
           create(:fulfilled_order, user: user_6, status: 0 )
         end
-        
+
         user_7 = create(:user, state: 'AK')
         5.times do
           create(:fulfilled_order, user: user_7, status: 2)
         end
-        
+
         states = ['HI', 'CO', 'CA']
-        
+
         expect(User.top_states).to eq(states)
       end
     end
@@ -184,42 +176,42 @@ RSpec.describe User, type: :model do
         user_1 = create(:user, city: 'Springfield', state: 'CO')
         create(:fulfilled_order, user: user_1)
         create(:fulfilled_order, user: user_1)
-        
+
         user_2 = create(:user, city: 'Honolulu', state: 'HI')
         4.times do
           create(:fulfilled_order, user: user_2)
         end
-        
+
         user_3 = create(:user, city: 'Claremont', state: 'CA')
         create(:fulfilled_order, user: user_3)
-        
+
         user_4 = create(:user, city: 'New York City', state: 'NY')
-        
+
         user_5 = create(:user, city: 'Honolulu', state: 'HI')
         create(:fulfilled_order, user: user_5)
-        
+
         user_6 = create(:user, city: 'Fairbanks', state: 'AK')
         6.times do
           create(:fulfilled_order, user: user_6, status: 0 )
         end
-        
+
         user_7 = create(:user, city: 'Fairbanks', state: 'AK')
         6.times do
           create(:fulfilled_order, user: user_7, status: 2)
         end
-        
+
         user_8 = create(:user, city: 'Springfield', state: 'MI')
         create(:fulfilled_order, user: user_8)
         create(:fulfilled_order, user: user_8)
         create(:fulfilled_order, user: user_8)
-        
+
         cities = [['Honolulu', 'HI'], ['Springfield', 'MI'], ['Springfield', 'CO']]
-        
+
         expect(User.top_cities).to eq(cities)
       end
     end
   end
-  
+
   describe 'Instance Methods' do
     describe '#enabled_toggle' do
       it 'toggles a user between enabled and disabled states' do


### PR DESCRIPTION
-Adds feature test for admin upgrading a default user to a merchant.
within that test: 
--An admin user can visit a user's show page via admin/users, and should see a link to upgrade the user to a merchants. (all other user types cannot reach this page)
--when an admin clicks on the link to upgrade the user, they are redirected to the admin/merchant show page for that user and see a flash message confirming the upgrade. *** I had to make a route that took the admin to admin/merchants show page, as the existing route still went to admin/users.*** Is this okay? Or is there a better way to do this?
--the upgraded user is now a merchant

-Also fixed the user default_users method test.

-All tests passing except for enable_toggle test

closes card #48 