### PR TITLE
User profile displays orders#54

### DIFF
--- a/app/controllers/profile/users_controller.rb
+++ b/app/controllers/profile/users_controller.rb
@@ -1,12 +1,12 @@
 class Profile::UsersController < ApplicationController
   before_action :require_default_user
-  
+
   def show
-    
+    @orders = current_user.orders
   end
-  
+
   def edit
     @user = current_user
   end
-  
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -22,4 +22,8 @@ class Order < ApplicationRecord
     OrderItem.where(order_id: id).sum(:quantity)
   end
 
+  def grand_total
+    OrderItem.where(order_id: id).sum("quantity * order_price")
+  end
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,7 +7,7 @@ class Order < ApplicationRecord
   has_many :items, through: :order_items
 
   enum status: [:pending, :fulfilled, :cancelled]
-  
+
   def self.biggest_orders
     joins(:order_items)
     .where(status: 1)
@@ -17,4 +17,9 @@ class Order < ApplicationRecord
     .order("item_count DESC")
     .limit(3)
   end
+
+  def item_quantity
+    OrderItem.where(order_id: id).sum(:quantity)
+  end
+
 end

--- a/app/views/profile/users/show.html.erb
+++ b/app/views/profile/users/show.html.erb
@@ -6,3 +6,9 @@
 <%= current_user.email %>
 
 <%= link_to 'Edit Profile', profile_edit_path %>
+
+<div id="order-listing" >
+  <% @orders.each do |order| %>
+    <%= link_to order.id, profile_orders_path(order.id) %>
+  <% end %>
+</div>

--- a/app/views/profile/users/show.html.erb
+++ b/app/views/profile/users/show.html.erb
@@ -13,5 +13,7 @@
     <%= "Placed on: #{order.created_at} " %>
     <%= "Last update: #{order.updated_at} " %>
     <%= "Status: #{order.status} " %>
+    <%= "Item count: #{order.item_quantity} " %>
+    <%= "Grand total: #{number_to_currency(order.grand_total/100)} " %>
   <% end %>
 </div>

--- a/app/views/profile/users/show.html.erb
+++ b/app/views/profile/users/show.html.erb
@@ -9,6 +9,9 @@
 
 <div id="order-listing" >
   <% @orders.each do |order| %>
-    <%= link_to order.id, profile_orders_path(order.id) %>
+    <%= link_to "Order: #{order.id} ", profile_orders_path(order.id) %>
+    <%= "Placed on: #{order.created_at} " %>
+    <%= "Last update: #{order.updated_at} " %>
+    <%= "Status: #{order.status} " %>
   <% end %>
 </div>

--- a/app/views/profile/users/show.html.erb
+++ b/app/views/profile/users/show.html.erb
@@ -7,13 +7,15 @@
 
 <%= link_to 'Edit Profile', profile_edit_path %>
 
-<div id="order-listing" >
-  <% @orders.each do |order| %>
-    <%= link_to "Order: #{order.id} ", profile_orders_path(order.id) %>
-    <%= "Placed on: #{order.created_at} " %>
-    <%= "Last update: #{order.updated_at} " %>
-    <%= "Status: #{order.status} " %>
-    <%= "Item count: #{order.item_quantity} " %>
-    <%= "Grand total: #{number_to_currency(order.grand_total/100)} " %>
-  <% end %>
-</div>
+<% @orders.each do |order| %>
+  <div id="order-<%=order.id%>">
+    <ul>
+      <li><%= link_to "Order: #{order.id} ", profile_orders_path(order.id) %></li>
+      <li><%= "Placed on: #{order.created_at} " %></li>
+      <li><%= "Last update: #{order.updated_at} " %></li>
+      <li><%= "Status: #{order.status} " %>
+      <li><%= "Item count: #{order.item_quantity} " %></li>
+      <li><%= "Grand total: #{number_to_currency(order.grand_total/100)} " %></li>
+    </ul>
+  </div>
+<% end %>

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -148,9 +148,15 @@ describe 'USER SHOW PAGE' do
       visit profile_path
 
       within "#order-listing" do
-        expect(page).to have_link(order_1.id)
+        expect(page).to have_link("Order: #{order_1.id}")
         expect(page).to have_link(order_2.id)
         expect(page).to have_link(order_3.id)
+
+        expect(page).to have_content("Placed on: #{order_2.created_at}")
+        expect(page).to have_content("Last update: #{order_2.updated_at}")
+        expect(page).to have_content("Status: #{order_2.status}")
+        #expect(page).to have_content(order_2.item_quantity)
+        #expect(page).to have_content(order_2.grand_total)
       end
     end
   end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -137,11 +137,17 @@ describe 'USER SHOW PAGE' do
       expect(find_field("user[password]").value).to eq(nil)
     end
 
-    it 'shows all of my orders' do
+    xit 'shows all of my orders' do
       user_1 = create(:user)
+
       order_1 = create(:fulfilled_order, user: user_1)
       order_2 = create(:fulfilled_order, user: user_1)
-      order_3 = create(:fulfilled_order, user: user_1)
+      order_3 = create(:order, user: user_1)
+
+      oi_1 = create(:fulfilled_order_item, order: order_1, quantity: 1, order_price: 100)
+      oi_2 = create(:fulfilled_order_item, order: order_2, quantity: 1, order_price: 200)
+      oi_3 = create(:fulfilled_order_item, order: order_2, quantity: 2, order_price: 300)
+      oi_4 = create(:unfulfilled_order_item, order: order_3, quantity: 2, order_price: 400)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 
@@ -155,7 +161,10 @@ describe 'USER SHOW PAGE' do
         expect(page).to have_content("Placed on: #{order_2.created_at}")
         expect(page).to have_content("Last update: #{order_2.updated_at}")
         expect(page).to have_content("Status: #{order_2.status}")
-        #expect(page).to have_content(order_2.item_quantity)
+
+        expect(page).to have_content("Total items: 1")
+        expect(page).to have_content("Total items: 3")
+        expect(page).to have_content("Total items: 2")
         #expect(page).to have_content(order_2.grand_total)
       end
     end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -153,6 +153,5 @@ describe 'USER SHOW PAGE' do
         expect(page).to have_link(order_3.id)
       end
     end
-    
   end
 end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -144,28 +144,37 @@ describe 'USER SHOW PAGE' do
       order_2 = create(:fulfilled_order, user: user_1)
       order_3 = create(:order, user: user_1)
 
-      oi_1 = create(:fulfilled_order_item, order: order_1, quantity: 1, order_price: 100)
-      oi_2 = create(:fulfilled_order_item, order: order_2, quantity: 1, order_price: 200)
-      oi_3 = create(:fulfilled_order_item, order: order_2, quantity: 2, order_price: 300)
-      oi_4 = create(:unfulfilled_order_item, order: order_3, quantity: 2, order_price: 400)
+      create(:fulfilled_order_item, order: order_1, quantity: 1, order_price: 100)
+      create(:fulfilled_order_item, order: order_2, quantity: 1, order_price: 200)
+      create(:fulfilled_order_item, order: order_2, quantity: 2, order_price: 300)
+      create(:unfulfilled_order_item, order: order_3, quantity: 2, order_price: 400)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
 
       visit profile_path
 
-      within "#order-listing" do
+      within "#order-#{order_1.id}" do
         expect(page).to have_link("Order: #{order_1.id}")
-        expect(page).to have_link(order_2.id)
-        expect(page).to have_link(order_3.id)
-
+        expect(page).to have_content("Placed on: #{order_1.created_at}")
+        expect(page).to have_content("Last update: #{order_1.updated_at}")
+        expect(page).to have_content("Status: #{order_1.status}")
+        expect(page).to have_content("Item count: 1")
+        expect(page).to have_content("Grand total: $1.00")
+      end
+      within "#order-#{order_2.id}" do
+        expect(page).to have_link("Order: #{order_2.id}")
         expect(page).to have_content("Placed on: #{order_2.created_at}")
         expect(page).to have_content("Last update: #{order_2.updated_at}")
         expect(page).to have_content("Status: #{order_2.status}")
-
-        expect(page).to have_content("Item count: 1")
         expect(page).to have_content("Item count: 3")
+        expect(page).to have_content("Grand total: $8.00")
+      end
+      within "#order-#{order_3.id}" do
+        expect(page).to have_link("Order: #{order_3.id}")
+        expect(page).to have_content("Placed on: #{order_3.created_at}")
+        expect(page).to have_content("Last update: #{order_3.updated_at}")
+        expect(page).to have_content("Status: #{order_3.status}")
         expect(page).to have_content("Item count: 2")
-
         expect(page).to have_content("Grand total: $8.00")
       end
     end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -42,6 +42,7 @@ describe 'USER SHOW PAGE' do
       expect(find_field("user[email]").value).to eq(user.email)
       expect(find_field("user[password]").value).to eq(nil)
     end
+
     it 'allows me to edit some of my information' do
       old_name = 'User One'
       old_city = 'City One'
@@ -69,6 +70,7 @@ describe 'USER SHOW PAGE' do
       expect(page).to_not have_content(old_name)
       expect(page).to_not have_content(old_city)
     end
+
     it 'allows me to edit all of my information' do
       old_name = 'User One'
       old_street = 'Street One'
@@ -113,6 +115,7 @@ describe 'USER SHOW PAGE' do
       expect(page).to_not have_content(old_zip)
       expect(page).to_not have_content(old_email)
     end
+
     it 'does not allow me to leave fields blank' do
       user = User.create(name: 'User One', street: 'Street One', city: 'City One', state: 'State1',
         zip: 'ZIP1', email: 'email1@aol.com', password: 'password1')
@@ -133,5 +136,23 @@ describe 'USER SHOW PAGE' do
       expect(find_field("user[email]").value).to eq(user.email)
       expect(find_field("user[password]").value).to eq(nil)
     end
+
+    it 'shows all of my orders' do
+      user_1 = create(:user)
+      order_1 = create(:fulfilled_order, user: user_1)
+      order_2 = create(:fulfilled_order, user: user_1)
+      order_3 = create(:fulfilled_order, user: user_1)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+
+      visit profile_path
+
+      within "#order-listing" do
+        expect(page).to have_link(order_1.id)
+        expect(page).to have_link(order_2.id)
+        expect(page).to have_link(order_3.id)
+      end
+    end
+    
   end
 end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -137,7 +137,7 @@ describe 'USER SHOW PAGE' do
       expect(find_field("user[password]").value).to eq(nil)
     end
 
-    xit 'shows all of my orders' do
+    it 'shows all of my orders' do
       user_1 = create(:user)
 
       order_1 = create(:fulfilled_order, user: user_1)
@@ -162,10 +162,11 @@ describe 'USER SHOW PAGE' do
         expect(page).to have_content("Last update: #{order_2.updated_at}")
         expect(page).to have_content("Status: #{order_2.status}")
 
-        expect(page).to have_content("Total items: 1")
-        expect(page).to have_content("Total items: 3")
-        expect(page).to have_content("Total items: 2")
-        #expect(page).to have_content(order_2.grand_total)
+        expect(page).to have_content("Item count: 1")
+        expect(page).to have_content("Item count: 3")
+        expect(page).to have_content("Item count: 2")
+
+        expect(page).to have_content("Grand total: $8.00")
       end
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -11,44 +11,57 @@ RSpec.describe Order, type: :model do
     it { should validate_presence_of(:status)}
     it { should validate_presence_of(:user_id)}
   end
-  
+
   describe 'Class Methods' do
     describe '.biggest_orders' do
       it 'should return the top 3 orders by quantity of items' do
         order_1 = create(:fulfilled_order)
         create(:fulfilled_order_item, order: order_1)
         create(:fulfilled_order_item, order: order_1)
-        
+
         order_2 = create(:fulfilled_order)
         4.times do
           create(:fulfilled_order_item, order: order_2)
         end
-        
+
         order_3 = create(:fulfilled_order)
         3.times do
           create(:fulfilled_order_item, order: order_3)
         end
-        
+
         order_4 = create(:fulfilled_order)
         create(:fulfilled_order_item, order: order_4)
         5.times do
           create(:unfulfilled_order_item, order: order_4)
         end
-        
+
         order_5 = create(:order)
         5.times do
           create(:fulfilled_order_item, order: order_5)
         end
-        
+
         order_6 = create(:cancelled_order)
         5.times do
           create(:fulfilled_order_item, order: order_6)
         end
-        
+
         orders = [order_2, order_3, order_1]
-        
+
         expect(Order.biggest_orders).to eq(orders)
       end
+    end
+  end
+
+  describe 'instance methods' do
+    it 'returns the quantity of items in an order' do
+      order_1 = create(:fulfilled_order)
+
+      create(:fulfilled_order_item, order: order_1, quantity: 1, order_price: 100)
+      create(:fulfilled_order_item, order: order_1, quantity: 1, order_price: 200)
+      create(:fulfilled_order_item, order: order_1, quantity: 2, order_price: 300)
+      create(:unfulfilled_order_item, order: order_1, quantity: 2, order_price: 400)
+
+      expect(order_1.item_quantity).to eq(6)
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -63,6 +63,17 @@ RSpec.describe Order, type: :model do
 
       expect(order_1.item_quantity).to eq(6)
     end
+    it 'returns the grand total for an order' do
+      order_1 = create(:fulfilled_order)
+
+      create(:fulfilled_order_item, order: order_1, quantity: 1, order_price: 100)
+      create(:fulfilled_order_item, order: order_1, quantity: 1, order_price: 200)
+      create(:fulfilled_order_item, order: order_1, quantity: 2, order_price: 300)
+      create(:unfulfilled_order_item, order: order_1, quantity: 2, order_price: 400)
+
+      expect(order_1.grand_total).to eq(1700)
+    end
+
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,28 +61,28 @@ RSpec.describe User, type: :model do
         4.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_1))
         end
-        
+
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2))
         create(:fulfilled_order_item, item: create(:item, user: merchant_2))
-        
+
         merchant_3 = create(:merchant)
-        
+
         merchant_4 = create(:merchant)
         3.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_4))
         end
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
-        
+
         merchant_5 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_5))
-        
+
         merchant_6 = create(:merchant, enabled: false)
         5.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_6))
         end
-        
+
         expect(User.merchants_by_quantity).to eq([merchant_1, merchant_4, merchant_2])
       end
     end
@@ -92,28 +92,28 @@ RSpec.describe User, type: :model do
         4.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_1),  order_price: 500)
         end
-        
+
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 4000)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), order_price: 5000)
-        
+
         merchant_3 = create(:merchant)
-        
+
         merchant_4 = create(:merchant)
         3.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_4),  order_price: 100)
         end
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
         create(:unfulfilled_order_item, item: create(:item, user: merchant_4))
-        
+
         merchant_5 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_5), order_price: 10000)
-        
+
         merchant_6 = create(:merchant, enabled: false)
         5.times do
           create(:fulfilled_order_item, item: create(:item, user: merchant_6), order_price: 10000)
         end
-        
+
         expect(User.merchants_by_price).to eq([merchant_5, merchant_2, merchant_1])
       end
     end
@@ -123,25 +123,25 @@ RSpec.describe User, type: :model do
         create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.day.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.hour.ago)
         create(:unfulfilled_order_item, item: create(:item, user: merchant_1), created_at: 1.minute.ago)
-        
+
         merchant_2 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), created_at: 2.hours.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_2), created_at: 2.hours.ago)
-        
+
         merchant_3 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 2.days.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 3.days.ago)
         create(:fulfilled_order_item, item: create(:item, user: merchant_3), created_at: 3.days.ago)
-        
+
         merchant_4 = create(:merchant)
         create(:fulfilled_order_item, item: create(:item, user: merchant_4), created_at: 4.days.ago)
-        
+
         merchant_5 = create(:merchant, enabled: false)
         create(:fulfilled_order_item, item: create(:item, user: merchant_5), created_at: 1.minute.ago)
-        
-        
+
+
         sorted_merchants = [merchant_2, merchant_1, merchant_3, merchant_4]
-        
+
         expect(User.merchants_by_time).to eq(sorted_merchants)
       end
     end
@@ -150,32 +150,32 @@ RSpec.describe User, type: :model do
         user_1 = create(:user, state: 'CO')
         create(:fulfilled_order, user: user_1)
         create(:fulfilled_order, user: user_1)
-        
+
         user_2 = create(:user, state: 'HI')
         create(:fulfilled_order, user: user_2)
         create(:fulfilled_order, user: user_2)
         create(:fulfilled_order, user: user_2)
-        
+
         user_3 = create(:user, state: 'CA')
         create(:fulfilled_order, user: user_3)
-        
+
         user_4 = create(:user, state: 'NY')
-        
+
         user_5 = create(:user, state: 'HI')
         create(:fulfilled_order, user: user_5)
-        
+
         user_6 = create(:user, state: 'AK')
         5.times do
           create(:fulfilled_order, user: user_6, status: 0 )
         end
-        
+
         user_7 = create(:user, state: 'AK')
         5.times do
           create(:fulfilled_order, user: user_7, status: 2)
         end
-        
+
         states = ['HI', 'CO', 'CA']
-        
+
         expect(User.top_states).to eq(states)
       end
     end
@@ -184,51 +184,38 @@ RSpec.describe User, type: :model do
         user_1 = create(:user, city: 'Springfield', state: 'CO')
         create(:fulfilled_order, user: user_1)
         create(:fulfilled_order, user: user_1)
-        
+
         user_2 = create(:user, city: 'Honolulu', state: 'HI')
         4.times do
           create(:fulfilled_order, user: user_2)
         end
-        
+
         user_3 = create(:user, city: 'Claremont', state: 'CA')
         create(:fulfilled_order, user: user_3)
-        
+
         user_4 = create(:user, city: 'New York City', state: 'NY')
-        
+
         user_5 = create(:user, city: 'Honolulu', state: 'HI')
         create(:fulfilled_order, user: user_5)
-        
+
         user_6 = create(:user, city: 'Fairbanks', state: 'AK')
         6.times do
           create(:fulfilled_order, user: user_6, status: 0 )
         end
-        
+
         user_7 = create(:user, city: 'Fairbanks', state: 'AK')
         6.times do
           create(:fulfilled_order, user: user_7, status: 2)
         end
-        
+
         user_8 = create(:user, city: 'Springfield', state: 'MI')
         create(:fulfilled_order, user: user_8)
         create(:fulfilled_order, user: user_8)
         create(:fulfilled_order, user: user_8)
-        
+
         cities = [['Honolulu', 'HI'], ['Springfield', 'MI'], ['Springfield', 'CO']]
-        
+
         expect(User.top_cities).to eq(cities)
-      end
-    end
-  end
-  
-  describe 'Instance Methods' do
-    describe '#enabled_toggle' do
-      it 'toggles a user between enabled and disabled states' do
-        user = User.create(name: 'User One', street: 'Street One', city: 'City One', state: 'State1',
-          zip: 'ZIP1', email: 'email1@aol.com', password: 'password1', role: 0, enabled: true)
-        user.enabled_toggle
-        expect(user.enabled).to eq(false)
-        user.enabled_toggle
-        expect(user.enabled).to eq(true)
       end
     end
   end


### PR DESCRIPTION
This pull request completes card #54. The user profile now displays a listing of user orders, including:

Order id (a link)
The time the order was placed
The last update
The quantity of items in the order
The grand total of items in the order

This pull request also deletes a method which was though to have been deleted earlier--for toggling a user's enabled status. It is no longer needed.

All tests pass.