### PR TITLE
Dashboard show#31

### DIFF
--- a/spec/features/merchant_show_page_spec.rb
+++ b/spec/features/merchant_show_page_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'as a merchant user' do
+  context 'when I visit my dashboard' do
+    it 'should show me my profile data, but I cannot edit it' do
+      merch = create(:merchant)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merch)
+
+      visit dashboard_path
+
+      expect(page).to have_content(merch.name)
+      expect(page).to have_content(merch.street)
+      expect(page).to have_content(merch.city)
+      expect(page).to have_content(merch.state)
+      expect(page).to have_content(merch.zip)
+      expect(page).to have_content(merch.email)
+      expect(page).to have_link('My Items')
+      expect(page).to_not have_link('Edit Profile')
+    end
+  end
+end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -177,6 +177,7 @@ describe 'USER SHOW PAGE' do
         expect(page).to have_content("Item count: 2")
         expect(page).to have_content("Grand total: $8.00")
       end
+    end 
     it 'should not see a link to upgrade' do
       user = create(:user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -211,16 +211,4 @@ RSpec.describe User, type: :model do
       end
     end
   end
-  describe 'Instance Methods' do
-    describe '#enabled_toggle' do
-      it 'toggles a user between enabled and disabled states' do
-        user = User.create(name: 'User One', street: 'Street One', city: 'City One', state: 'State1',
-          zip: 'ZIP1', email: 'email1@aol.com', password: 'password1', role: 0, enabled: true)
-        user.enabled_toggle
-        expect(user.enabled).to eq(false)
-        user.enabled_toggle
-        expect(user.enabled).to eq(true)
-      end
-    end
-  end
 end


### PR DESCRIPTION
-Adds test for merchant dashboard page to confirm that a merchant sees their data, but cannot edit it.
-All of the implementation code was already there, so this one was just writing a test. 
-All tests passing - removed enable toggle test from user spec


closes #31 