### PR TITLE
Error messages#110

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,13 +30,9 @@ class UsersController < ApplicationController
       redirect_to profile_path
       flash[:success] = "You are now registered and logged in."
     else
-      @user.errors.each do |attr, msg|
-        if msg == "can't be blank"
-          flash[:field_alert] = 'Required fields are missing'
-        elsif attr == :email && msg == "has already been taken"
-          flash[:email_alert] = 'Email address is already in use'
-          @user.email = nil
-        end
+      @errors = @user.errors
+      if @errors.full_messages.include?("Email has already been taken")
+        @user.email = nil
       end
       render :new
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,6 @@ class UsersController < ApplicationController
       flash[:success] = 'You have updated your profile'
       redirect_to profile_path
     else
-      # flash[:field_alert] = 'Required fields are missing'
       @user = current_user
       render :edit
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,8 +51,9 @@ class UsersController < ApplicationController
       flash[:success] = 'You have updated your profile'
       redirect_to profile_path
     else
-      flash[:field_alert] = 'Required fields are missing'
-      redirect_to profile_edit_path
+      # flash[:field_alert] = 'Required fields are missing'
+      @user = current_user
+      render :edit
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,8 @@ class UsersController < ApplicationController
       flash[:success] = 'You have updated your profile'
       redirect_to profile_path
     else
-      @user = current_user
+      @user = User.find(params[:id])
+      @errors = current_user.errors
       render :edit
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
                         :email, :role
   validates_presence_of :password, if: :password
   validates :enabled, inclusion: {in: [true, false]}
-  validates :email, uniqueness: true
+  validates_uniqueness_of :email
 
   has_many :orders
   has_many :items

--- a/app/views/users/_registration_form.html.erb
+++ b/app/views/users/_registration_form.html.erb
@@ -1,4 +1,9 @@
-<%= form_for @user do |f| %>
+<%= form_for @user do |f| %>  
+  <ul>
+  <% @user.errors.full_messages.each do |error| %>
+    <li><%= error %></li>
+  <% end %>
+  </ul>
   <%= f.label :name %>
   <%= f.text_field :name %>
   <%= f.label :street %>

--- a/app/views/users/_registration_form.html.erb
+++ b/app/views/users/_registration_form.html.erb
@@ -1,7 +1,9 @@
 <%= form_for @user do |f| %>  
   <ul>
-  <% @user.errors.full_messages.each do |error| %>
-    <li><%= error %></li>
+  <% if @errors %>
+    <% @errors.full_messages.each do |error| %>
+      <li><%= error %></li>
+    <% end %>
   <% end %>
   </ul>
   <%= f.label :name %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,8 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  host: localhost
+
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
@@ -24,6 +26,7 @@ default: &default
 development:
   <<: *default
   database: little_shop_development
+  host: localhost
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -58,6 +61,7 @@ development:
 test:
   <<: *default
   database: little_shop_test
+  host: localhost
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -81,5 +85,6 @@ test:
 production:
   <<: *default
   database: little_shop_production
+  host: localhost
   username: little_shop
   password: <%= ENV['LITTLE_SHOP_DATABASE_PASSWORD'] %>

--- a/spec/features/user_can_register_spec.rb
+++ b/spec/features/user_can_register_spec.rb
@@ -47,7 +47,7 @@ describe 'as a visitor, when I visit /' do
         fill_in :user_password, with: "password1"
         click_on 'Submit'
 
-        expect(page).to have_content('Email address is already in use')
+        expect(page).to have_content('Email has already been taken')
         expect(find_field("user[name]").value).to eq("User One")
         expect(find_field("user[street]").value).to eq("Street One")
         expect(find_field("user[city]").value).to eq("City One")

--- a/spec/features/user_can_register_spec.rb
+++ b/spec/features/user_can_register_spec.rb
@@ -74,7 +74,7 @@ describe 'as a visitor, when I visit /' do
         fill_in :user_password, with: "password1"
         click_on 'Submit'
 
-        expect(page).to have_content('Email address is already in use')
+        expect(page).to have_content('Email has already been taken')
         expect(find_field("user[name]").value).to eq("User One")
         expect(find_field("user[street]").value).to eq("Street One")
         expect(find_field("user[city]").value).to eq("City One")
@@ -96,7 +96,7 @@ describe 'as a visitor, when I visit /' do
         fill_in :user_password, with: "password1"
         click_on 'Submit'
 
-        expect(page).to have_content('Required fields are missing')
+        expect(page).to have_content("Zip can't be blank")
         expect(find_field("user[name]").value).to eq("User One")
         expect(find_field("user[street]").value).to eq("Street One")
         expect(find_field("user[city]").value).to eq("City One")
@@ -105,6 +105,17 @@ describe 'as a visitor, when I visit /' do
 
         expect(find_field("user[zip]").value).to eq("")
         expect(find_field("user[password]").value).to eq(nil)
+        
+        visit registration_path
+        click_on 'Submit'
+        
+        expect(page).to have_content("Name can't be blank")
+        expect(page).to have_content("Street can't be blank")
+        expect(page).to have_content("City can't be blank")
+        expect(page).to have_content("State can't be blank")
+        expect(page).to have_content("Zip can't be blank")
+        expect(page).to have_content("Email can't be blank")
+        expect(page).to have_content("Password can't be blank")
       end
     end
   end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -143,5 +143,29 @@ describe 'USER SHOW PAGE' do
       expect(page).to have_content("State can't be blank")
       expect(page).to have_content("Zip can't be blank")
     end
+    
+    it 'does not allow me to update my email address to one that is already in use' do
+      other_email = 'other@aol.com'
+
+      create(:user, email: other_email)
+
+      user = create(:user)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit profile_edit_path
+
+      fill_in :user_email, with: other_email
+      click_button 'Submit'
+
+      expect(page).to have_content('Email has already been taken')
+      expect(find_field("user[name]").value).to eq(user.name)
+      expect(find_field("user[street]").value).to eq(user.street)
+      expect(find_field("user[city]").value).to eq(user.city)
+      expect(find_field("user[state]").value).to eq(user.state)
+      expect(find_field("user[zip]").value).to eq(user.zip)
+      expect(find_field("user[email]").value).to eq(user.email)
+      expect(find_field("user[password]").value).to eq(nil)
+    end
   end
 end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -123,8 +123,7 @@ describe 'USER SHOW PAGE' do
       fill_in :user_name, with: ''
       click_button 'Submit'
 
-      expect(current_path).to eq(profile_edit_path)
-      expect(page).to have_content('Required fields are missing')
+      expect(page).to have_content("Name can't be blank")
       expect(find_field("user[name]").value).to eq(user.name)
       expect(find_field("user[street]").value).to eq(user.street)
       expect(find_field("user[city]").value).to eq(user.city)
@@ -132,6 +131,17 @@ describe 'USER SHOW PAGE' do
       expect(find_field("user[zip]").value).to eq(user.zip)
       expect(find_field("user[email]").value).to eq(user.email)
       expect(find_field("user[password]").value).to eq(nil)
+      
+      fill_in :user_street, with: ''
+      fill_in :user_city, with: ''
+      fill_in :user_state, with: ''
+      fill_in :user_zip, with: ''
+      click_button 'Submit'
+      
+      expect(page).to have_content("Street can't be blank")
+      expect(page).to have_content("City can't be blank")
+      expect(page).to have_content("State can't be blank")
+      expect(page).to have_content("Zip can't be blank")
     end
   end
 end

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -122,7 +122,8 @@ describe 'USER SHOW PAGE' do
 
       fill_in :user_name, with: ''
       click_button 'Submit'
-
+      
+      user = User.find(user.id)
       expect(page).to have_content("Name can't be blank")
       expect(find_field("user[name]").value).to eq(user.name)
       expect(find_field("user[street]").value).to eq(user.street)
@@ -137,7 +138,8 @@ describe 'USER SHOW PAGE' do
       fill_in :user_state, with: ''
       fill_in :user_zip, with: ''
       click_button 'Submit'
-      
+
+      user = User.find(user.id)      
       expect(page).to have_content("Street can't be blank")
       expect(page).to have_content("City can't be blank")
       expect(page).to have_content("State can't be blank")
@@ -157,6 +159,8 @@ describe 'USER SHOW PAGE' do
 
       fill_in :user_email, with: other_email
       click_button 'Submit'
+      
+      user = User.find(user.id)
 
       expect(page).to have_content('Email has already been taken')
       expect(find_field("user[name]").value).to eq(user.name)

--- a/spec/features/user_show_page_spec.rb
+++ b/spec/features/user_show_page_spec.rb
@@ -146,10 +146,10 @@ describe 'USER SHOW PAGE' do
     
     it 'does not allow me to update my email address to one that is already in use' do
       other_email = 'other@aol.com'
-
       create(:user, email: other_email)
-
-      user = create(:user)
+      
+      email = 'email@aol.com'
+      user = create(:user, email: email)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -164,7 +164,8 @@ describe 'USER SHOW PAGE' do
       expect(find_field("user[city]").value).to eq(user.city)
       expect(find_field("user[state]").value).to eq(user.state)
       expect(find_field("user[zip]").value).to eq(user.zip)
-      expect(find_field("user[email]").value).to eq(user.email)
+      expect(find_field("user[email]").value).to eq(email)
+      expect(user.email).to eq(email)
       expect(find_field("user[password]").value).to eq(nil)
     end
   end


### PR DESCRIPTION
Updates our registration/update user form to user error messages rather than flash messages. This makes for a better user experience since it will show exactly what field is missing or wrong (e.g. "Name can't be blank"), rather than the more generic "Required fields are missing". 
It adds an instance variable `@error` to handle the error messages. Updates existing tests to reflect the new verbiage and adds new tests. 
All tests passing (except defunct enabled_toggle which will be removed). 
Closes card #110 