### PR TITLE
Merchant dashboard orders#30

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,6 @@
+class OrdersController < ApplicationController
+  
+  def show
+    
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    @merchant_pending_orders = Order.merchant_pending_orders(current_user.id)
   end
 
   def new

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -37,5 +37,10 @@ class Order < ApplicationRecord
     .where("items.user_id = ?", merchant_id)
     .count
   end
-
+  
+  def merchant_items_value(merchant_id)
+    items
+    .where("items.user_id = ?", merchant_id)
+    .sum("order_items.order_price")
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -22,6 +22,7 @@ class Order < ApplicationRecord
     joins(:items)
     .where("items.user_id = ?", merchant_id)
     .where(status: :pending)
+    .group(:id)
   end
 
   def item_quantity

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -17,6 +17,12 @@ class Order < ApplicationRecord
     .order("item_count DESC")
     .limit(3)
   end
+  
+  def self.merchant_pending_orders(merchant_id)
+    joins(:items)
+    .where("items.user_id = ?", merchant_id)
+    .where(status: :pending)
+  end
 
   def item_quantity
     OrderItem.where(order_id: id).sum(:quantity)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -31,5 +31,11 @@ class Order < ApplicationRecord
   def grand_total
     OrderItem.where(order_id: id).sum("quantity * order_price")
   end
+  
+  def merchant_items_quantity(merchant_id)
+    items
+    .where("items.user_id = ?", merchant_id)
+    .count
+  end
 
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,8 +15,8 @@
       <ul>
         <li>Order #<%= order.id %></li>
         <li>Order #<%= order.created_at %></li>
-        <li>Order #<%= order.merchant_items_quantity %></li>
-        <li>Order #<%= order.merchant_items_value %></li>
+        <li>Order #<%= order.merchant_items_quantity(current_user.id) %></li>
+        <li>Order #<%= order.merchant_items_value(current_user.id) %></li>
       </ul>
     </div>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,17 @@
 
 
 <% if current_default? %>
-<%= link_to 'Edit Profile', profile_edit_path %>
+  <%= link_to 'Edit Profile', profile_edit_path %>
 <% elsif current_merchant? %>
-<%= link_to 'My Items', dashboard_items_path %>
+  <%= link_to 'My Items', dashboard_items_path %>
+  <% @merchant_pending_orders.each do |order| %>
+    <div id="pending-order-<%= order.id %>">
+      <ul>
+        <li>Order #<%= order.id %></li>
+        <li>Order #<%= order.created_at %></li>
+        <li>Order #<%= order.merchant_items_quantity %></li>
+        <li>Order #<%= order.merchant_items_value %></li>
+      </ul>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,9 +14,9 @@
     <div id="pending-order-<%= order.id %>">
       <ul>
         <li><%= link_to "Order ##{order.id}", dashboard_orders_path(order) %></li>
-        <li>Placed on: <%= order.created_at %></li>
+        <li>Placed on: <%= order.created_at.strftime('%B %d, %Y') %></li>
         <li>My items in order: <%= order.merchant_items_quantity(current_user.id) %></li>
-        <li>My items value: <%= order.merchant_items_value(current_user.id) %></li>
+        <li>My items value: <%= number_to_currency(order.merchant_items_value(current_user.id) / 100) %></li>
       </ul>
     </div>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,10 +13,10 @@
   <% @merchant_pending_orders.each do |order| %>
     <div id="pending-order-<%= order.id %>">
       <ul>
-        <li>Order #<%= order.id %></li>
-        <li>Order #<%= order.created_at %></li>
-        <li>Order #<%= order.merchant_items_quantity(current_user.id) %></li>
-        <li>Order #<%= order.merchant_items_value(current_user.id) %></li>
+        <li><%= link_to "Order ##{order.id}", dashboard_orders_path(order) %></li>
+        <li>Placed on: <%= order.created_at %></li>
+        <li>My items in order: <%= order.merchant_items_quantity(current_user.id) %></li>
+        <li>My items value: <%= order.merchant_items_value(current_user.id) %></li>
       </ul>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get '/merchants', as: :merchants, to: "users#index"
   get '/dashboard', as: :dashboard, to: "users#show"
   get '/dashboard/items', to: "items#index"
+  get '/dashboard/orders/:id', as: :dashboard_orders, to: "orders#show"
 
 
   resources :items, only: [:index, :show]

--- a/spec/features/merchant_show_page_spec.rb
+++ b/spec/features/merchant_show_page_spec.rb
@@ -24,8 +24,20 @@ describe 'as a merchant user' do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
       
       order_1 = create(:order)
-      item_1 = create(:unfulfilled_order_item, order: order_1)
-      item_2 = create(:unfulfilled_order_item, order: order_1)      
+      item_1 = create(:item, user: merchant)
+      create(:unfulfilled_order_item, order: order_1, item: item_1)
+      create(:unfulfilled_order_item, order: order_1) 
+      
+      order_2 = create(:order)
+      create(:unfulfilled_order_item, order: order_2)
+      
+      order_3 = create(:order)
+      item_2 = create(:item, user: merchant)
+      create(:fulfilled_order_item, order: order_3, item: item_2)
+      
+      order_4 = create(:fulfilled_order)
+      item_3 = create(:item, user: merchant)
+      create(:fulfilled_order_item, order: order_4, item: item_3)     
       
       visit dashboard_path
       

--- a/spec/features/merchant_show_page_spec.rb
+++ b/spec/features/merchant_show_page_spec.rb
@@ -44,8 +44,8 @@ describe 'as a merchant user' do
       within "#pending-order-#{order_1.id}" do
         expect(page).to have_link("Order ##{order_1.id}")
         expect(page).to have_content("Placed on: #{order_1.created_at}")
-        expect(page).to have_content("My items in order: #{order_1.merchant_items_quantity}")
-        expect(page).to have_content("My items value: #{order_1.merchant_items_value}")
+        expect(page).to have_content("My items in order: #{order_1.merchant_items_quantity(merchant.id)}")
+        expect(page).to have_content("My items value: #{order_1.merchant_items_value(merchant.id)}")
         click_link "Order ##{order_1.id}"
       end
       

--- a/spec/features/merchant_show_page_spec.rb
+++ b/spec/features/merchant_show_page_spec.rb
@@ -21,7 +21,7 @@ describe 'as a merchant user' do
     
     it 'should show me a list of pending orders containing my items' do
       merchant = create(:merchant)
-      allow_any_instance_of(ApplicationController).to recieve(current_user).and_return(merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
       
       order_1 = create(:order)
       item_1 = create(:unfulfilled_order_item, order: order_1)
@@ -32,8 +32,8 @@ describe 'as a merchant user' do
       within "#pending-order-#{order_1.id}" do
         expect(page).to have_link("Order ##{order_1.id}")
         expect(page).to have_content("Placed on: #{order_1.created_at}")
-        expect(page).to have_content("My items in order: #{order_1.my_items_quantity}")
-        expect(page).to have_content("My items value: #{order_1.my_items_value}")
+        expect(page).to have_content("My items in order: #{order_1.merchant_items_quantity}")
+        expect(page).to have_content("My items value: #{order_1.merchant_items_value}")
         click_link "Order ##{order_1.id}"
       end
       

--- a/spec/features/merchant_show_page_spec.rb
+++ b/spec/features/merchant_show_page_spec.rb
@@ -18,5 +18,27 @@ describe 'as a merchant user' do
       expect(page).to have_link('My Items')
       expect(page).to_not have_link('Edit Profile')
     end
+    
+    it 'should show me a list of pending orders containing my items' do
+      merchant = create(:merchant)
+      allow_any_instance_of(ApplicationController).to recieve(current_user).and_return(merchant)
+      
+      order_1 = create(:order)
+      item_1 = create(:unfulfilled_order_item, order: order_1)
+      item_2 = create(:unfulfilled_order_item, order: order_1)      
+      
+      visit dashboard_path
+      
+      within "#pending-order-#{order_1.id}" do
+        expect(page).to have_link("Order ##{order_1.id}")
+        expect(page).to have_content("Placed on: #{order_1.created_at}")
+        expect(page).to have_content("My items in order: #{order_1.my_items_quantity}")
+        expect(page).to have_content("My items value: #{order_1.my_items_value}")
+        click_link "Order ##{order_1.id}"
+      end
+      
+      expect(current_path).to eq(dashboard_orders_path(order_1))
+      
+    end
   end
 end

--- a/spec/features/merchant_show_page_spec.rb
+++ b/spec/features/merchant_show_page_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'as a merchant user' do
+  include ActionView::Helpers::NumberHelper
+  
   context 'when I visit my dashboard' do
     it 'should show me my profile data, but I cannot edit it' do
       merch = create(:merchant)
@@ -49,27 +51,33 @@ describe 'as a merchant user' do
       
       within "#pending-order-#{order_1.id}" do
         expect(page).to have_link("Order ##{order_1.id}")
-        expect(page).to have_content("Placed on: #{order_1.created_at}")
+        expect(page).to have_content("Placed on: #{order_1.created_at.strftime('%B %d, %Y')}")
+        save_and_open_page
+        
         expect(page).to have_content("My items in order: #{order_1.merchant_items_quantity(merchant.id)}")
-        expect(page).to have_content("My items value: #{order_1.merchant_items_value(merchant.id)}")
+        expect(page).to have_content("My items value: #{number_to_currency(order_1.merchant_items_value(merchant.id) / 100)}")
         click_link "Order ##{order_1.id}"
       end
       
       expect(current_path).to eq(dashboard_orders_path(order_1))
+      expect(current_path).to eq("/dashboard/orders/#{order_1.id}")
       
       visit dashboard_path
       
       expect(page).to_not have_css("#pending-order-#{order_2.id}")
+      expect(page).to_not have_css("#pending-order-#{order_4.id}")
       
       within "#pending-order-#{order_3.id}" do
         expect(page).to have_link("Order ##{order_3.id}")
-        expect(page).to have_content("Placed on: #{order_3.created_at}")
+        expect(page).to have_content("Placed on: #{order_3.created_at.to_date}")
+        
         expect(page).to have_content("My items in order: #{order_3.merchant_items_quantity(merchant.id)}")
-        expect(page).to have_content("My items value: #{order_3.merchant_items_value(merchant.id)}")
+        expect(page).to have_content("My items value: #{number_to_currency(order_3.merchant_items_value(merchant.id) / 100)}")
         click_link "Order ##{order_3.id}"
       end
       
-      expect(page).to_not have_css("#pending-order-#{order_4.id}")
+      expect(current_path).to eq(dashboard_orders_path(order_3))
+      
       
     end
   end

--- a/spec/features/merchant_show_page_spec.rb
+++ b/spec/features/merchant_show_page_spec.rb
@@ -52,7 +52,6 @@ describe 'as a merchant user' do
       within "#pending-order-#{order_1.id}" do
         expect(page).to have_link("Order ##{order_1.id}")
         expect(page).to have_content("Placed on: #{order_1.created_at.strftime('%B %d, %Y')}")
-        save_and_open_page
         
         expect(page).to have_content("My items in order: #{order_1.merchant_items_quantity(merchant.id)}")
         expect(page).to have_content("My items value: #{number_to_currency(order_1.merchant_items_value(merchant.id) / 100)}")
@@ -69,7 +68,7 @@ describe 'as a merchant user' do
       
       within "#pending-order-#{order_3.id}" do
         expect(page).to have_link("Order ##{order_3.id}")
-        expect(page).to have_content("Placed on: #{order_3.created_at.to_date}")
+        expect(page).to have_content("Placed on: #{order_3.created_at.strftime('%B %d, %Y')}")
         
         expect(page).to have_content("My items in order: #{order_3.merchant_items_quantity(merchant.id)}")
         expect(page).to have_content("My items value: #{number_to_currency(order_3.merchant_items_value(merchant.id) / 100)}")

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -143,7 +143,8 @@ RSpec.describe Order, type: :model do
       total_2 = o_i_3.order_price
       
       expect(order_1.merchant_items_value(merchant.id)).to eq(total_1)
-      expect(order_2.merchant_items_value(merchant.id)).to eq(total_2)
+      expect(order_2.merchant_items_value(merchant.id)).to eq(0)
+      expect(order_3.merchant_items_value(merchant.id)).to eq(total_2)
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -114,11 +114,36 @@ RSpec.describe Order, type: :model do
       
       order_3 = create(:order)
       item_3 = create(:item, user: merchant)
-      create(:fulfilled_order_item, order: order_3, item: item_2)
+      create(:fulfilled_order_item, order: order_3, item: item_3)
       
       expect(order_1.merchant_items_quantity(merchant.id)).to eq(2)
       expect(order_2.merchant_items_quantity(merchant.id)).to eq(0)
       expect(order_3.merchant_items_quantity(merchant.id)).to eq(1)
+    end
+  end
+  
+  describe '#merchant_items_value' do
+    it 'returns the value of all of a merchants items in an order' do
+      merchant = create(:merchant)
+      
+      order_1 = create(:order)
+      item_1 = create(:item, user: merchant)
+      item_2 = create(:item, user: merchant)
+      o_i_1 = create(:unfulfilled_order_item, order: order_1, item: item_1)
+      o_i_2 = create(:unfulfilled_order_item, order: order_1, item: item_2) 
+      total_1 = o_i_1.order_price + o_i_2.order_price
+      
+      order_2 = create(:order)
+      create(:unfulfilled_order_item, order: order_2)
+      
+      order_3 = create(:order)
+      item_3 = create(:item, user: merchant)
+      o_i_3 = create(:fulfilled_order_item, order: order_3, item: item_3)
+      create(:unfulfilled_order_item, order: order_3)
+      total_2 = o_i_3.order_price
+      
+      expect(order_1.merchant_items_value(merchant.id)).to eq(total_1)
+      expect(order_2.merchant_items_value(merchant.id)).to eq(total_2)
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -50,6 +50,30 @@ RSpec.describe Order, type: :model do
         expect(Order.biggest_orders).to eq(orders)
       end
     end
+    
+    describe '.merchant_pending_orders' do
+      it 'should return all the pending orders for a merchant where they have items' do
+        merchant = create(:merchant)
+        
+        order_1 = create(:order)
+        item_1 = create(:item, user: merchant)
+        create(:unfulfilled_order_item, order: order_1, item: item_1)
+        create(:unfulfilled_order_item, order: order_1) 
+        
+        order_2 = create(:order)
+        create(:unfulfilled_order_item, order: order_2)
+        
+        order_3 = create(:order)
+        item_2 = create(:item, user: merchant)
+        create(:fulfilled_order_item, order: order_3, item: item_2)
+        
+        order_4 = create(:fulfilled_order)
+        item_3 = create(:item, user: merchant)
+        create(:fulfilled_order_item, order: order_4, item: item_3)
+        
+        expect(Order.merchant_pending_orders(merchant.id)).to eq([order_1, order_3])
+      end
+    end
   end
 
   describe 'instance methods' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -97,7 +97,29 @@ RSpec.describe Order, type: :model do
 
       expect(order_1.grand_total).to eq(1700)
     end
-
+  end
+  
+  describe '#merchant_items_quantity' do
+    it 'returns the quantity of items the specified merchant has in the order' do
+      merchant = create(:merchant)
+      
+      order_1 = create(:order)
+      item_1 = create(:item, user: merchant)
+      item_2 = create(:item, user: merchant)
+      create(:unfulfilled_order_item, order: order_1, item: item_1)
+      create(:unfulfilled_order_item, order: order_1, item: item_2) 
+      
+      order_2 = create(:order)
+      create(:unfulfilled_order_item, order: order_2)
+      
+      order_3 = create(:order)
+      item_3 = create(:item, user: merchant)
+      create(:fulfilled_order_item, order: order_3, item: item_2)
+      
+      expect(order_1.merchant_items_quantity(merchant.id)).to eq(2)
+      expect(order_2.merchant_items_quantity(merchant.id)).to eq(0)
+      expect(order_3.merchant_items_quantity(merchant.id)).to eq(1)
+    end
   end
 
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Order, type: :model do
       order_3 = create(:order)
       item_3 = create(:item, user: merchant)
       create(:fulfilled_order_item, order: order_3, item: item_3)
+      create(:unfulfilled_order_item, order: order_3)
       
       expect(order_1.merchant_items_quantity(merchant.id)).to eq(2)
       expect(order_2.merchant_items_quantity(merchant.id)).to eq(0)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe Order, type: :model do
         
         order_3 = create(:order)
         item_2 = create(:item, user: merchant)
+        item_4 = create(:item, user: merchant)
         create(:fulfilled_order_item, order: order_3, item: item_2)
+        create(:fulfilled_order_item, order: order_3, item: item_4)
         
         order_4 = create(:fulfilled_order)
         item_3 = create(:item, user: merchant)


### PR DESCRIPTION
Completes User Story 39,  Merchant Dashboard Displays Orders
- Adds list of pending orders with items belonging to the merchant to the merchant dashboard page
- Each order includes a link to the order show page (nested under /dashboard), the date the order was made, the quantity of the merchant's items in that order, and the total value of the merchant's items in that order. 
- Implements methods in the Order model for items belonging to a particular merchant, as well as for quantity of items in an order belonging to a merchant and value of items in an order belonging to a merchant.
- All tests passing. 

Closes #30 