### PR TITLE
Merchant deletes item#14

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,5 +15,9 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    item = Item.find(params[:id])
+    Item.delete(item)
+    flash[:notice] = "Item ##{item.id} has been deleted"
+    redirect_to dashboard_items_path
   end
 end

--- a/spec/features/merchant_item_index_spec.rb
+++ b/spec/features/merchant_item_index_spec.rb
@@ -77,6 +77,10 @@ describe 'as a merchant user' do
     
     it 'should allow me to delete items' do
       merchant = create(:merchant)
+      visit login_path
+      fill_in :email, with: merchant.email
+      fill_in :password, with: merchant.password
+      click_button 'Log In'
       
       item_1 = create(:item, user: merchant)
       item_2 = create(:item, user: merchant)
@@ -87,13 +91,12 @@ describe 'as a merchant user' do
       expect(page).to have_content(item_1.name)
       expect(page).to have_content(item_2.name)
       expect(page).to have_content(item_3.name)
-      
       within "#item-#{item_1.id}" do
         click_on 'Delete this item' 
       end
       
       expect(current_path).to eq(dashboard_items_path)
-      expect(page).to have_content("Item ##{item_1.id}, #{item_1.name}, has been deleted")
+      expect(page).to have_content("Item ##{item_1.id} has been deleted")
       expect(page).to_not have_content(item_1.name)
       expect(page).to_not have_content(item_1.description)
       expect(page).to have_content(item_2.name)

--- a/spec/features/merchant_item_index_spec.rb
+++ b/spec/features/merchant_item_index_spec.rb
@@ -74,5 +74,30 @@ describe 'as a merchant user' do
         expect(page).to_not have_link('Enable this item')
       end
     end
+    
+    it 'should allow me to delete items' do
+      merchant = create(:merchant)
+      
+      item_1 = create(:item, user: merchant)
+      item_2 = create(:item, user: merchant)
+      item_3 = create(:item, user: merchant)
+      
+      visit dashboard_items_path
+      
+      expect(page).to have_content(item_1.name)
+      expect(page).to have_content(item_2.name)
+      expect(page).to have_content(item_3.name)
+      
+      within "#item-#{item_1.id}" do
+        click_on 'Delete this item' 
+      end
+      
+      expect(current_path).to eq(dashboard_items_path)
+      expect(page).to have_content("Item ##{item_1.id}, #{item_1.name}, has been deleted")
+      expect(page).to_not have_content(item_1.name)
+      expect(page).to_not have_content(item_1.description)
+      expect(page).to have_content(item_2.name)
+      expect(page).to have_content(item_3.name)
+    end
   end
 end


### PR DESCRIPTION
Completes User Story 53, Merchant Deletes an Item
- Adds ability for merchant to delete items.
- Adds flash message letting the merchant know that the item has been deleted
- All tests passing
Closes #14 