### PR TITLE
Merchant order show page#7

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,7 @@
 class OrdersController < ApplicationController
   
+  before_action :require_merchant_user, only: [:show]
+  
   def show
     order = Order.find(params[:id])
     @customer = order.user

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,8 @@
 class OrdersController < ApplicationController
   
   def show
-    @customer = Order.find(params[:id]).user
+    order = Order.find(params[:id])
+    @customer = order.user
+    @items = order.merchant_items(current_user)
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,6 +3,6 @@ class OrdersController < ApplicationController
   def show
     order = Order.find(params[:id])
     @customer = order.user
-    @items = order.merchant_items(current_user)
+    @items = order.merchant_items(current_user.id)
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,6 @@
 class OrdersController < ApplicationController
   
   def show
-    
+    @customer = Order.find(params[:id]).user
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,6 +3,6 @@ class OrdersController < ApplicationController
   def show
     order = Order.find(params[:id])
     @customer = order.user
-    @items = order.merchant_items(current_user.id)
+    @items_with_quantity = order.merchant_items_with_quantity(current_user.id)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -44,4 +44,8 @@ class Order < ApplicationRecord
     .where("items.user_id = ?", merchant_id)
     .sum("order_items.order_price")
   end
+  
+  def merchant_items(merchant_id)
+    items.where("items.user_id = ?", merchant_id)
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -45,7 +45,10 @@ class Order < ApplicationRecord
     .sum("order_items.order_price")
   end
   
-  def merchant_items(merchant_id)
-    items.where("items.user_id = ?", merchant_id)
+  def merchant_items_with_quantity(merchant_id)
+    items = self.items.where("items.user_id = ?", merchant_id)
+    items.map do |item|
+      [item, self.order_items.find_by(item_id: item.id).quantity]
+    end
   end
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -6,10 +6,13 @@
     <%= @customer.city %> <%= @customer.state %> <%= @customer.zip %>
   </p>
 </div>
-<% @items.each do |item| %>
+<% @items_with_quantity.each do |item, quantity| %>
   <div id="item-<%= item.id %>">
+    <%= image_tag(item.image_link, class:"thumbnails") %>
     <ul>
-      <li><%= item.name %></li>
+      <li><%= link_to item.name, item_path(item) %></li>
+      <li>Price: <%= item.current_price %></li>
+      <li>Quantity: <%= quantity %></li>
     </ul>
   </div>
 <% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -6,3 +6,10 @@
     <%= @customer.city %> <%= @customer.state %> <%= @customer.zip %>
   </p>
 </div>
+<% @items.each do |item| %>
+  <div id="item-<%= item.id %>">
+    <ul>
+      <li><%= item.name %></li>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -11,7 +11,7 @@
     <%= image_tag(item.image_link, class:"thumbnails") %>
     <ul>
       <li><%= link_to item.name, item_path(item) %></li>
-      <li>Price: <%= item.current_price %></li>
+      <li>Price: <%= number_to_currency(item.current_price / 100) %></li>
       <li>Quantity: <%= quantity %></li>
     </ul>
   </div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,0 +1,8 @@
+<div id="customer-info">
+  Customer Information
+  <p>Name: <%= @customer.name %> </p>
+  <p>Address: <br />
+    <%= @customer.street %><br />
+    <%= @customer.city %> <%= @customer.state %> <%= @customer.zip %>
+  </p>
+</div>

--- a/spec/features/merchant_order_show_page_spec.rb
+++ b/spec/features/merchant_order_show_page_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'As a merchant' do
+  context 'when I visit an order show page' do
+    it 'shows information about the customer and my items that are being purchased' do
+      merchant = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+      item_1 = create(:item, user: merchant)
+      item_2 = create(:item, user: merchant)
+      
+      item_3 = create(:item)
+      
+      customer = create(:user)
+      order = create(:order, user: customer)
+      create(:fulfilled_order_item, order: order, item: item_1)
+      create(:unfulfilled_order_item, order: order, item: item_2)
+      create(:fulfilled_order_item, order: order, item: item_3)
+      
+      visit dashboard_orders_path(order)
+      
+      within "#customer-info" do
+        expect(page).to have_content("Name: #{customer.name}")
+        expect(page).to have_content("Address: #{customer.street}\n#{customer.city} #{customer.state} #{customer.zip}")
+      end
+      
+      expect(page).to have_content(item_1.name)
+      expect(page).to have_content(item_2.name)
+      expect(page).to_not have_content(item_3.name)
+      expect(page).to_not have_css("#item-#{item_3.id}")
+      expect(page).to have_css("#item-#{item_1.id}")
+      expect(page).to have_css("#item-#{item_2.id}")
+    end
+  end
+end

--- a/spec/features/merchant_order_show_page_spec.rb
+++ b/spec/features/merchant_order_show_page_spec.rb
@@ -9,6 +9,7 @@ describe 'As a merchant' do
       item_2 = create(:item, user: merchant)
       
       item_3 = create(:item)
+      item_4 = create(:item, user: merchant)
       
       customer = create(:user)
       order = create(:order, user: customer)
@@ -26,9 +27,37 @@ describe 'As a merchant' do
       expect(page).to have_content(item_1.name)
       expect(page).to have_content(item_2.name)
       expect(page).to_not have_content(item_3.name)
+      expect(page).to_not have_content(item_4.name)
       expect(page).to_not have_css("#item-#{item_3.id}")
+      expect(page).to_not have_css("#item-#{item_4.id}")
       expect(page).to have_css("#item-#{item_1.id}")
       expect(page).to have_css("#item-#{item_2.id}")
+    end
+    
+    it 'should should information about my items on the page' do
+      merchant = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+      item_1 = create(:item, user: merchant)
+      item_2 = create(:item, user: merchant)
+      
+      order = create(:order)
+      oi_1 = create(:fulfilled_order_item, order: order, item: item_1)
+      oi_2 = create(:unfulfilled_order_item, order: order, item: item_2)
+      
+      visit dashboard_orders_path(order)
+      
+      within "#item-#{item_1.id}" do
+        expect(page).to have_link("#{item_1.name}")
+        expect(page).to have_css("img[src='#{item_1.image_link}']")
+        expect(page).to have_content("Price: #{item_1.current_price}")
+        expect(page).to have_content("Quantity: #{oi_1.quantity}")
+      end
+      within "#item-#{item_2.id}" do
+        expect(page).to have_link("#{item_2.name}")
+        expect(page).to have_css("img[src='#{item_2.image_link}']")
+        expect(page).to have_content("Price: #{item_2.current_price}")
+        expect(page).to have_content("Quantity: #{oi_2.quantity}")
+      end
     end
   end
 end

--- a/spec/features/merchant_order_show_page_spec.rb
+++ b/spec/features/merchant_order_show_page_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'As a merchant' do
+  include ActionView::Helpers::NumberHelper
+  
   context 'when I visit an order show page' do
     it 'shows information about the customer and my items that are being purchased' do
       merchant = create(:merchant)
@@ -49,15 +51,22 @@ describe 'As a merchant' do
       within "#item-#{item_1.id}" do
         expect(page).to have_link("#{item_1.name}")
         expect(page).to have_css("img[src='#{item_1.image_link}']")
-        expect(page).to have_content("Price: #{item_1.current_price}")
+        expect(page).to have_content("Price: #{number_to_currency(item_1.current_price / 100)}")
         expect(page).to have_content("Quantity: #{oi_1.quantity}")
+        click_link "#{item_1.name}"
       end
+      expect(current_path).to eq(item_path(item_1))
+      
+      visit dashboard_orders_path(order)
+      
       within "#item-#{item_2.id}" do
         expect(page).to have_link("#{item_2.name}")
         expect(page).to have_css("img[src='#{item_2.image_link}']")
-        expect(page).to have_content("Price: #{item_2.current_price}")
+        expect(page).to have_content("Price: #{number_to_currency(item_2.current_price / 100)}")
         expect(page).to have_content("Quantity: #{oi_2.quantity}")
+        click_link "#{item_2.name}"
       end
+      expect(current_path).to eq(item_path(item_2))
     end
   end
 end

--- a/spec/features/merchant_order_show_page_spec.rb
+++ b/spec/features/merchant_order_show_page_spec.rb
@@ -68,5 +68,23 @@ describe 'As a merchant' do
       end
       expect(current_path).to eq(item_path(item_2))
     end
+    
+    it 'should not let a non-merchant see the above info' do
+      merchant = create(:merchant)
+      item_1 = create(:item, user: merchant)
+      item_2 = create(:item, user: merchant)
+      order = create(:order)
+      oi_1 = create(:fulfilled_order_item, order: order, item: item_1)
+      oi_2 = create(:unfulfilled_order_item, order: order, item: item_2)
+      
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      
+      visit dashboard_orders_path(order)
+      
+      expect(page.status_code).to eq(404)
+      expect(page).to_not have_content(item_1.name)
+      expect(page).to_not have_content(item_2.name)
+    end
   end
 end

--- a/spec/features/merchant_order_show_page_spec.rb
+++ b/spec/features/merchant_order_show_page_spec.rb
@@ -20,7 +20,7 @@ describe 'As a merchant' do
       
       within "#customer-info" do
         expect(page).to have_content("Name: #{customer.name}")
-        expect(page).to have_content("Address: #{customer.street}\n#{customer.city} #{customer.state} #{customer.zip}")
+        expect(page).to have_content("Address: #{customer.street} #{customer.city} #{customer.state} #{customer.zip}")
       end
       
       expect(page).to have_content(item_1.name)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -99,56 +99,72 @@ RSpec.describe Order, type: :model do
 
       expect(order_1.grand_total).to eq(1700)
     end
-  end
   
-  describe '#merchant_items_quantity' do
-    it 'returns the quantity of items the specified merchant has in the order' do
-      merchant = create(:merchant)
-      
-      order_1 = create(:order)
-      item_1 = create(:item, user: merchant)
-      item_2 = create(:item, user: merchant)
-      create(:unfulfilled_order_item, order: order_1, item: item_1)
-      create(:unfulfilled_order_item, order: order_1, item: item_2) 
-      
-      order_2 = create(:order)
-      create(:unfulfilled_order_item, order: order_2)
-      
-      order_3 = create(:order)
-      item_3 = create(:item, user: merchant)
-      create(:fulfilled_order_item, order: order_3, item: item_3)
-      create(:unfulfilled_order_item, order: order_3)
-      
-      expect(order_1.merchant_items_quantity(merchant.id)).to eq(2)
-      expect(order_2.merchant_items_quantity(merchant.id)).to eq(0)
-      expect(order_3.merchant_items_quantity(merchant.id)).to eq(1)
+    describe '#merchant_items_quantity' do
+      it 'returns the quantity of items the specified merchant has in the order' do
+        merchant = create(:merchant)
+        
+        order_1 = create(:order)
+        item_1 = create(:item, user: merchant)
+        item_2 = create(:item, user: merchant)
+        create(:unfulfilled_order_item, order: order_1, item: item_1)
+        create(:unfulfilled_order_item, order: order_1, item: item_2) 
+        
+        order_2 = create(:order)
+        create(:unfulfilled_order_item, order: order_2)
+        
+        order_3 = create(:order)
+        item_3 = create(:item, user: merchant)
+        create(:fulfilled_order_item, order: order_3, item: item_3)
+        create(:unfulfilled_order_item, order: order_3)
+        
+        expect(order_1.merchant_items_quantity(merchant.id)).to eq(2)
+        expect(order_2.merchant_items_quantity(merchant.id)).to eq(0)
+        expect(order_3.merchant_items_quantity(merchant.id)).to eq(1)
+      end
+    end
+    
+    describe '#merchant_items_value' do
+      it 'returns the value of all of a merchants items in an order' do
+        merchant = create(:merchant)
+        
+        order_1 = create(:order)
+        item_1 = create(:item, user: merchant)
+        item_2 = create(:item, user: merchant)
+        o_i_1 = create(:unfulfilled_order_item, order: order_1, item: item_1)
+        o_i_2 = create(:unfulfilled_order_item, order: order_1, item: item_2) 
+        total_1 = o_i_1.order_price + o_i_2.order_price
+        
+        order_2 = create(:order)
+        create(:unfulfilled_order_item, order: order_2)
+        
+        order_3 = create(:order)
+        item_3 = create(:item, user: merchant)
+        o_i_3 = create(:fulfilled_order_item, order: order_3, item: item_3)
+        create(:unfulfilled_order_item, order: order_3)
+        total_2 = o_i_3.order_price
+        
+        expect(order_1.merchant_items_value(merchant.id)).to eq(total_1)
+        expect(order_2.merchant_items_value(merchant.id)).to eq(0)
+        expect(order_3.merchant_items_value(merchant.id)).to eq(total_2)
+      end
+    end
+    
+    describe '#merchant_items' do
+      it 'returns the items in an order that belong to the specified merchant' do
+        merchant = create(:merchant)
+        item_1 = create(:item, user: merchant)
+        item_2 = create(:item, user: merchant)
+        
+        item_3 = create(:item)
+        
+        order = create(:order)
+        create(:fulfilled_order_item, order: order, item: item_1)
+        create(:unfulfilled_order_item, order: order, item: item_2)
+        create(:fulfilled_order_item, order: order, item: item_3)
+        
+        expect(order.merchant_items(merchant).to eq([item_1, item_2]))
+      end
     end
   end
-  
-  describe '#merchant_items_value' do
-    it 'returns the value of all of a merchants items in an order' do
-      merchant = create(:merchant)
-      
-      order_1 = create(:order)
-      item_1 = create(:item, user: merchant)
-      item_2 = create(:item, user: merchant)
-      o_i_1 = create(:unfulfilled_order_item, order: order_1, item: item_1)
-      o_i_2 = create(:unfulfilled_order_item, order: order_1, item: item_2) 
-      total_1 = o_i_1.order_price + o_i_2.order_price
-      
-      order_2 = create(:order)
-      create(:unfulfilled_order_item, order: order_2)
-      
-      order_3 = create(:order)
-      item_3 = create(:item, user: merchant)
-      o_i_3 = create(:fulfilled_order_item, order: order_3, item: item_3)
-      create(:unfulfilled_order_item, order: order_3)
-      total_2 = o_i_3.order_price
-      
-      expect(order_1.merchant_items_value(merchant.id)).to eq(total_1)
-      expect(order_2.merchant_items_value(merchant.id)).to eq(0)
-      expect(order_3.merchant_items_value(merchant.id)).to eq(total_2)
-    end
-  end
-
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe Order, type: :model do
       end
     end
     
-    describe '#merchant_items' do
-      it 'returns the items in an order that belong to the specified merchant' do
+    describe '#merchant_items_with_quantity' do
+      it 'returns the items in an order that belong to the specified merchant, with the quantity' do
         merchant = create(:merchant)
         item_1 = create(:item, user: merchant)
         item_2 = create(:item, user: merchant)
@@ -160,11 +160,11 @@ RSpec.describe Order, type: :model do
         item_4 = create(:item, user: merchant)
         
         order = create(:order)
-        create(:fulfilled_order_item, order: order, item: item_1)
-        create(:unfulfilled_order_item, order: order, item: item_2)
+        create(:fulfilled_order_item, order: order, item: item_1, quantity: 2)
+        create(:unfulfilled_order_item, order: order, item: item_2, quantity: 1)
         create(:fulfilled_order_item, order: order, item: item_3)
         
-        expect(order.merchant_items(merchant.id)).to eq([item_1, item_2])
+        expect(order.merchant_items_with_quantity(merchant.id)).to eq([[item_1, 2], [item_2, 1]])
       end
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -157,13 +157,14 @@ RSpec.describe Order, type: :model do
         item_2 = create(:item, user: merchant)
         
         item_3 = create(:item)
+        item_4 = create(:item, user: merchant)
         
         order = create(:order)
         create(:fulfilled_order_item, order: order, item: item_1)
         create(:unfulfilled_order_item, order: order, item: item_2)
         create(:fulfilled_order_item, order: order, item: item_3)
         
-        expect(order.merchant_items(merchant).to eq([item_1, item_2]))
+        expect(order.merchant_items(merchant.id)).to eq([item_1, item_2])
       end
     end
   end


### PR DESCRIPTION
Completes User Story 59, Merchant sees an order show page
- Adds content to the merchant order show page: 
  - Customer information (name and address)
  - Item information (name, thumbnail, price, quantity the customer wants to purchase)
- Adds Order instance method to return the specified merchant's items in that order, along with their quantity
- Adds controller logic 
- Adds controller logic so only merchants can access the page
- All tests passing, 99.96% coverage
Closes #7 