### PR TITLE
Merchant item enable#15

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -44,6 +44,10 @@ class ItemsController < ApplicationController
       item.update(:enabled => false)
       flash[:success] = "#{item.name} is no longer for sale."
       redirect_to dashboard_items_path
+    else
+      item.update(:enabled => true)
+      flash[:success] = "#{item.name} is now available for sale."
+      redirect_to dashboard_items_path
     end
   end
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -37,6 +37,7 @@
         <%= link_to 'Delete this item', dashboard_item_path(:id => item.id), method: :delete %>
       <% end %>
       <% if item.enabled %>
+        <p>This item is enabled.</p>
         <%= link_to 'Disable this item', dashboard_item_path(item), method: :put %>
       <% else %>
         <p>This item is disabled.</p>

--- a/spec/features/merchant_item_index_spec.rb
+++ b/spec/features/merchant_item_index_spec.rb
@@ -144,14 +144,14 @@ describe 'as a merchant user' do
   context 'when I click on the enable button for an item' do
     it 'should return me to my items page, I should see a message notifying me the item is now available for sale,
       and I see the item is now enabled' do
-      merch1 = create(:merchant)
-      item_1 = create(:item, user: merch1)
+      merch = create(:merchant)
+      item_1 = create(:item, user: merch)
       fulfilled_1 = create(:fulfilled_order_item, item: item_1)
-      item_2 = create(:disabled_item, user: merch1)
+      item_2 = create(:disabled_item, user: merch)
 
       visit login_path
-      fill_in :email, with: merch1.email
-      fill_in :password, with: merch1.password
+      fill_in :email, with: merch.email
+      fill_in :password, with: merch.password
       click_button 'Log In'
 
       visit dashboard_items_path

--- a/spec/features/merchant_item_index_spec.rb
+++ b/spec/features/merchant_item_index_spec.rb
@@ -129,6 +129,7 @@ describe 'as a merchant user' do
       within("#item-#{item_2.id}") do
         expect(page).to have_content(item_2.id)
         expect(page).to have_content('This item is disabled')
+        expect(page).to_not have_content('This item is enabled')
         expect(page).to have_content(item_2.name)
         expect(page).to have_css("img[src*='#{item_2.image_link}']")
         expect(page).to have_content(item_2.current_price)
@@ -136,6 +137,44 @@ describe 'as a merchant user' do
         expect(page).to have_link('Edit this item')
         expect(page).to have_link('Enable this item')
         expect(page).to_not have_link('Disable this item')
+        expect(page).to have_link('Delete this item')
+      end
+    end
+  end
+  context 'when I click on the enable button for an item' do
+    it 'should return me to my items page, I should see a message notifying me the item is now available for sale,
+      and I see the item is now enabled' do
+      merch1 = create(:merchant)
+      item_1 = create(:item, user: merch1)
+      fulfilled_1 = create(:fulfilled_order_item, item: item_1)
+      item_2 = create(:disabled_item, user: merch1)
+
+      visit login_path
+      fill_in :email, with: merch1.email
+      fill_in :password, with: merch1.password
+      click_button 'Log In'
+
+      visit dashboard_items_path
+
+      within("#item-#{item_2.id}") do
+       expect(page).to have_link('Enable this item')
+       click_on('Enable this item')
+      end
+
+      expect(current_path).to eq(dashboard_items_path)
+      expect(page).to have_content("#{item_2.name} is now available for sale.")
+
+      within("#item-#{item_2.id}") do
+        expect(page).to have_content(item_2.id)
+        expect(page).to_not have_content('This item is disabled')
+        expect(page).to have_content('This item is enabled')
+        expect(page).to have_content(item_2.name)
+        expect(page).to have_css("img[src*='#{item_2.image_link}']")
+        expect(page).to have_content(item_2.current_price)
+        expect(page).to have_content(item_2.inventory)
+        expect(page).to have_link('Edit this item')
+        expect(page).to_not have_link('Enable this item')
+        expect(page).to have_link('Disable this item')
         expect(page).to have_link('Delete this item')
       end
     end


### PR DESCRIPTION
-Adds test for merchant enabling an item. The item controller update method now has an else condition for the enabled check where the enabling is done. A flash success message has been added.
-Added one expectation to previous disable test to now expect to not see the text that the item is enabled.
-All tests passing

closes #15 